### PR TITLE
Windows: not resolving references-runtime.js from server-functions package

### DIFF
--- a/packages/vinxi-server-functions/client.js
+++ b/packages/vinxi-server-functions/client.js
@@ -1,11 +1,12 @@
 import { directives, shimExportsPlugin } from "@vinxi/plugin-directives";
 import { fileURLToPath } from "url";
 import { chunkify } from "vinxi/lib/chunks";
+import { normalize } from "vinxi/lib/path";
 
 import { CLIENT_REFERENCES_MANIFEST } from "./constants.js";
 
 export function client({
-	runtime = fileURLToPath(new URL("./references-runtime.js", import.meta.url)),
+	runtime = normalize(fileURLToPath(new URL("./references-runtime.js", import.meta.url))),
 	manifest = CLIENT_REFERENCES_MANIFEST,
 } = {}) {
 	const serverModules = new Set();


### PR DESCRIPTION
Running `example-bare` from solid-start on Windows fails to resolve `references-runtime.js`.

```cmd
[plugin:vite:import-analysis] Failed to resolve import "C:UsersDavideDesktopsolid-start
ode_modules.pnpm@vinxi+plugin-server-functions@0.0.32_vinxi@0.0.40
ode_modules@vinxiplugin-server-functions
eferences-runtime.js" from "src\entry-client.tsx". Does the file exist?
C:/Users/Davide/Desktop/solid-start/examples/bare/src/entry-client.tsx:1:38
1  |  import { createComponent as _$createComponent } from "solid-js/web";
2  |  import { createServerReference } from 'C:\Users\Davide\Desktop\solid-start\node_modules\.pnpm\@vinxi+plugin-server-functions@0.0.32_vinxi@0.0.40\node_modules\@vinxi\plugin-server-functions\references-runtime.js';
   |                                         ^
3  |  import { mount, StartClient } from "@solidjs/start/client";
4  |  const hello = createServerReference(() => {}, "C:/Users/Davide/Desktop/solid-start/examples/bare/src/entry-client.tsx?split=0", "default");
    at formatError (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:44694:46)
    at TransformContext.error (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:44688:19)
    at normalizeUrl (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:42423:33)
    at async file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:42572:47
    at async Promise.all (index 1)
    at async TransformContext.transform (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:42493:13)
    at async Object.transform (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:44996:30)
    at async loadAndTransform (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-beta.7/node_modules/vite/dist/node/chunks/dep-7af400e9.js:55818:29)
    at async viteTransformMiddleware (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@5.0.0-
```