### PR TITLE
Enable JS Link Preload

### DIFF
--- a/.changeset/old-eggs-travel.md
+++ b/.changeset/old-eggs-travel.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: include more than css assets

--- a/packages/vinxi/lib/manifest/prod-server-manifest.js
+++ b/packages/vinxi/lib/manifest/prod-server-manifest.js
@@ -7,6 +7,23 @@ import findAssetsInViteManifest from "./vite-manifest.js";
 
 /** @typedef {import("../app.js").App & { config: { buildManifest: { [key:string]: any } }}} ProdApp */
 
+function createHtmlTagsForAssets(router, assets) {
+	return assets.filter(
+		(asset) =>
+			asset.endsWith(".css") || asset.endsWith(".js"),
+	)
+	.map((asset) => ({
+		tag: "link",
+		attrs: {
+			href: join(router.base, asset),
+			key: join(router.base, asset),
+			...(asset.endsWith(".css")
+				? { rel: "stylesheet", precendence: "high" }
+				: { rel: "modulepreload" }),
+		},
+	}));
+}
+
 /**
  *
  * @param {ProdApp} app
@@ -104,21 +121,7 @@ export function createProdManifest(app) {
 											: input;
 									return {
 										assets() {
-											return findAssetsInViteManifest(bundlerManifest, id)
-												.filter(
-													(asset) =>
-														asset.endsWith(".css") || asset.endsWith(".js"),
-												)
-												.map((asset) => ({
-													tag: "link",
-													attrs: {
-														href: join(router.base, asset),
-														key: join(router.base, asset),
-														...(asset.endsWith(".css")
-															? { rel: "stylesheet", precendence: "high" }
-															: { rel: "modulepreload" }),
-													},
-												}));
+											return createHtmlTagsForAssets(router, findAssetsInViteManifest(bundlerManifest, id));
 										},
 										output: {
 											path: join(
@@ -143,21 +146,7 @@ export function createProdManifest(app) {
 											);
 										},
 										assets() {
-											return findAssetsInViteManifest(bundlerManifest, id)
-												.filter(
-													(asset) =>
-														asset.endsWith(".css") || asset.endsWith(".js"),
-												)
-												.map((asset) => ({
-													tag: "link",
-													attrs: {
-														href: join(router.base, asset),
-														key: join(router.base, asset),
-														...(asset.endsWith(".css")
-															? { rel: "stylesheet", precendence: "high" }
-															: { rel: "modulepreload" }),
-													},
-												}));
+											return createHtmlTagsForAssets(router, findAssetsInViteManifest(bundlerManifest, id));
 										},
 										output: {
 											path: join(router.base, bundlerManifest[id].file),

--- a/packages/vinxi/lib/manifest/prod-server-manifest.js
+++ b/packages/vinxi/lib/manifest/prod-server-manifest.js
@@ -1,8 +1,9 @@
 import invariant from "vinxi/lib/invariant";
 import { handlerModule, join, virtualId } from "vinxi/lib/path";
 
-import findAssetsInViteManifest from "./vite-manifest.js";
 import { pathToFileURL } from "node:url";
+
+import findAssetsInViteManifest from "./vite-manifest.js";
 
 /** @typedef {import("../app.js").App & { config: { buildManifest: { [key:string]: any } }}} ProdApp */
 
@@ -67,7 +68,9 @@ export function createProdManifest(app) {
 										if (globalThis.$$chunks[chunk + ".js"]) {
 											return globalThis.$$chunks[chunk + ".js"];
 										}
-										return import(/* @vite-ignore */ pathToFileURL(chunkPath).href);
+										return import(
+											/* @vite-ignore */ pathToFileURL(chunkPath).href
+										);
 									},
 									output: {
 										path: chunkPath,
@@ -102,14 +105,18 @@ export function createProdManifest(app) {
 									return {
 										assets() {
 											return findAssetsInViteManifest(bundlerManifest, id)
-												.filter((asset) => asset.endsWith(".css"))
+												.filter(
+													(asset) =>
+														asset.endsWith(".css") || asset.endsWith(".js"),
+												)
 												.map((asset) => ({
 													tag: "link",
 													attrs: {
 														href: join(router.base, asset),
 														key: join(router.base, asset),
-														rel: "stylesheet",
-														precendence: "high",
+														...(asset.endsWith(".css")
+															? { rel: "stylesheet", precendence: "high" }
+															: { rel: "modulepreload" }),
 													},
 												}));
 										},
@@ -137,14 +144,18 @@ export function createProdManifest(app) {
 										},
 										assets() {
 											return findAssetsInViteManifest(bundlerManifest, id)
-												.filter((asset) => asset.endsWith(".css"))
+												.filter(
+													(asset) =>
+														asset.endsWith(".css") || asset.endsWith(".js"),
+												)
 												.map((asset) => ({
 													tag: "link",
 													attrs: {
 														href: join(router.base, asset),
 														key: join(router.base, asset),
-														rel: "stylesheet",
-														precendence: "high",
+														...(asset.endsWith(".css")
+															? { rel: "stylesheet", precendence: "high" }
+															: { rel: "modulepreload" }),
 													},
 												}));
 										},


### PR DESCRIPTION
This PR expands the assets returned from the manifest to include JS files.

The approach I took here was to map them to `<link>` elements with `rel="modulepreload"`. I hope this fits with what is intended. I needed to do extra filtering in start to handle lazyRoutes properly and inject them in the head the way I wanted to but I think in general we need to expose these assets.