### PR TITLE
close vite dev server

### DIFF
--- a/packages/vinxi/lib/dev-server.js
+++ b/packages/vinxi/lib/dev-server.js
@@ -200,6 +200,13 @@ export async function createDevServer(
 	return {
 		...devApp,
 		listen: () => devApp.listen(port, {}),
-		close: () => devApp.close(),
+		close: async () => {
+			await devApp.close();
+			await Promise.all(
+				app.config.routers
+					.filter(router => router.internals.devServer)
+					.map(router => router.internals.devServer?.close())
+			);
+		},
 	};
 }


### PR DESCRIPTION
When the dev server restarts because of config changes vite dev server are not closed keeping i.e. hmr websocket server running and ports occupied.

Now when the dev server is closed all vite dev server are also closed.


