### PR TITLE
normalize paths from fs watcher

### DIFF
--- a/.changeset/bright-baboons-sing.md
+++ b/.changeset/bright-baboons-sing.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: normalize paths from fs watcher

--- a/packages/vinxi/lib/fs-router.js
+++ b/packages/vinxi/lib/fs-router.js
@@ -6,6 +6,7 @@ import fs from "fs";
 import micromatch from "micromatch";
 import { posix } from "path";
 import { pathToRegexp } from "path-to-regexp";
+import { normalize } from "./path";
 
 export { pathToRegexp };
 
@@ -158,6 +159,7 @@ export class BaseFileSystemRouter extends EventTarget {
 	 * @param {string} src
 	 */
 	async addRoute(src) {
+		src = normalize(src);
 		if (this.isRoute(src)) {
 			const route = await this.toRoute(src);
 			if (route) {
@@ -187,6 +189,7 @@ export class BaseFileSystemRouter extends EventTarget {
 	 * @param {string} src
 	 */
 	async updateRoute(src) {
+		src = normalize(src);
 		if (this.isRoute(src)) {
 			const route = await this.toRoute(src);
 			if (route) {
@@ -203,6 +206,7 @@ export class BaseFileSystemRouter extends EventTarget {
 	 * @returns
 	 */
 	removeRoute(src) {
+		src = normalize(src);
 		if (this.isRoute(src)) {
 			const path = this.toPath(src);
 			if (path === undefined) {

--- a/packages/vinxi/lib/plugins/fs-watcher.js
+++ b/packages/vinxi/lib/plugins/fs-watcher.js
@@ -11,19 +11,19 @@ function setupWatcher(watcher, router) {
 	if (router.internals?.routes) {
 		watcher.on("unlink", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.removeRoute(path);
+				await router.internals?.routes.removeRoute(normalize(path));
 			}
 		});
 
 		watcher.on("add", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.addRoute(path);
+				await router.internals?.routes.addRoute(normalize(path));
 			}
 		});
 
 		watcher.on("change", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.updateRoute(path);
+				await router.internals?.routes.updateRoute(normalize(path));
 			}
 		});
 	}

--- a/packages/vinxi/lib/plugins/fs-watcher.js
+++ b/packages/vinxi/lib/plugins/fs-watcher.js
@@ -11,19 +11,19 @@ function setupWatcher(watcher, router) {
 	if (router.internals?.routes) {
 		watcher.on("unlink", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.removeRoute(normalize(path));
+				await router.internals?.routes.removeRoute(path);
 			}
 		});
 
 		watcher.on("add", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.addRoute(normalize(path));
+				await router.internals?.routes.addRoute(path);
 			}
 		});
 
 		watcher.on("change", async (path) => {
 			if (router.internals?.routes) {
-				await router.internals?.routes.updateRoute(normalize(path));
+				await router.internals?.routes.updateRoute(path);
 			}
 		});
 	}


### PR DESCRIPTION
- Be on Windows
- Run `pnpm -F example-hackernews run dev` in `solid start`
- Edit `[...stories].tsx`

Something to do with server functions I think but in any case it's probably a good idea to normalize the paths received from the fs watcher.

Edit: Moved the normalization to the fs-router in case other code modifies the routes in the future. 
```
14:09:40 [vite] hmr update /@id/C:/Users/Davide/Desktop/solid-start/examples/hackernews/src/routes/[...stories].tsx?pick=default&pick=$css
14:09:40 [vite] page reload src/routes/[...stories].tsx
outes[...stories].tsx?pick=route (resolved id: C:UsersDavideDesktopsolid-startexampleshackernewssroutes[...stories].tsx?pick=route) in C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js. Does the file exist?
14:09:41 [vite] Error when evaluating SSR module /@fs/C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routeoutes[...stories].tsx?pick=route"videDesktopsolid-startexampleshackernewssrc
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

14:09:41 [vite] Error when evaluating SSR module /@fs/C:/Users/Davide/Desktop/solid-start/packages/start/shared/routes.ts: failed to import "/@fs/C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js" 
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

14:09:41 [vite] Error when evaluating SSR module /@fs/C:/Users/Davide/Desktop/solid-start/packages/start/server/handler.tsx: failed to import "/@fs/C:/Users/Davide/Desktop/solid-start/packages/start/shared/routes.ts"
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

14:09:41 [vite] Error when evaluating SSR module /@fs/C:/Users/Davide/Desktop/solid-start/packages/start/server/index.tsx: failed to import "/@fs/C:/Users/Davide/Desktop/solid-start/packages/start/server/handler.tsx"
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

14:09:41 [vite] Error when evaluating SSR module /src/entry-server.tsx: failed to import "/@fs/C:/Users/Davide/Desktop/solid-start/packages/start/server/index.tsx"
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

14:09:41 [vite] Error when evaluating SSR module #vinxi/handler/ssr: failed to import "/src/entry-server.tsx"
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
    at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9)

outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'    at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
    ... 2 lines matching cause stack trace ...
    at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9) {
outes[...stories].tsx?pick=route' imported from 'C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js'      at nodeImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56088:25)
      at ssrImport (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:55990:30)
      at eval (C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vinxi@0.0.54_@types+node@20.10.1_debug@4.3.4_rollup@3.28.1/node_modules/vinxi/lib/routes.js:5:37)
      at async instantiateModule (file:///C:/Users/Davide/Desktop/solid-start/node_modules/.pnpm/vite@4.5.0_@types+node@20.10.1/node_modules/vite/dist/node/chunks/dep-bb8a8339.js:56052:9) {       
    code: 'ERR_MODULE_NOT_FOUND'
  },
  statusCode: 500,
  fatal: false,
  unhandled: true,
  statusMessage: undefined,
  data: undefined
}
```