### PR TITLE
Add additional CLI commands

### DIFF
--- a/.changeset/old-squids-fetch.md
+++ b/.changeset/old-squids-fetch.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+(feat): add additional CLI shortcuts (u -> show URL, h -> show help, r -> restart dev server)

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -66,6 +66,8 @@ const command = defineCommand({
 				const app = await loadApp(configFile, args);
 
 				let devServer;
+				/** @type {import('@vinxi/listhen').Listener} */
+				let listener;
 				/** @type {import('chokidar').FSWatcher} */
 				let watcher;
 
@@ -92,9 +94,7 @@ const command = defineCommand({
 								restartDevServer(app);
 								break;
 							case "u":
-								log(
-									`http://localhost:${args.port ?? process.env.PORT ?? 3000}`,
-								);
+								listener.showURL();
 								break;
 							case "q":
 								process.exit(0);
@@ -115,7 +115,7 @@ const command = defineCommand({
 						port: Number(args.port ?? process.env.PORT ?? 3000),
 					});
 					log("restarting dev server");
-					devServer.listen();
+					listener = await devServer.listen();
 				}
 
 				if (!app) {
@@ -146,7 +146,7 @@ const command = defineCommand({
 					port: Number(args.port ?? process.env.PORT ?? 3000),
 					devtools: args.devtools || Boolean(process.env.DEVTOOLS),
 				});
-				devServer.listen();
+				listener = await devServer.listen();
 			},
 		},
 		build: {

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -96,6 +96,8 @@ const command = defineCommand({
 									`http://localhost:${args.port ?? process.env.PORT ?? 3000}`,
 								);
 								break;
+							case "q":
+								process.exit(0);
 							case "h":
 								log("Shortcuts:\n");
 								log("  r - Restart dev server");

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -87,8 +87,20 @@ const command = defineCommand({
 				function createKeypressWatcher() {
 					emitKeypressEvents(process.stdin);
 					process.stdin.on("keypress", async (_, key) => {
-						if (key.name === "r") {
-							restartDevServer(app);
+						switch (key.name) {
+							case "r":
+								restartDevServer(app);
+								break;
+							case "u":
+								log(
+									`http://localhost:${args.port ?? process.env.PORT ?? 3000}`,
+								);
+								break;
+							case "h":
+								log("Shortcuts:\n");
+								log("  r - Restart dev server");
+								log("  u - Show server URL");
+								log("  h - Show help");
 						}
 					});
 				}
@@ -196,7 +208,9 @@ const command = defineCommand({
 			async run({ args }) {
 				process.env.PORT ??= args.port ?? 3000;
 				process.env.HOST ??= args.host ?? "0.0.0.0";
-				await import(pathToFileURL(process.cwd() + "/.output/server/index.mjs").href);
+				await import(
+					pathToFileURL(process.cwd() + "/.output/server/index.mjs").href
+				);
 			},
 		},
 	}),


### PR DESCRIPTION
Ported over more commands present in solid-start beta 1.

I haven't yet implemented opening in browser.

There's this [extract](https://github.com/withastro/astro/blob/main/packages/astro/src/cli/docs/open.ts) from the Astro CLI, which we also use in the solid CLI. Would this be ok to include in Vinxi to add this functionality?