### PR TITLE
fix: skip transform for vite-imagetools

### DIFF
--- a/packages/vinxi/lib/router-modes.js
+++ b/packages/vinxi/lib/router-modes.js
@@ -228,6 +228,11 @@ const routerModes = {
 				const { createViteHandler } = await import("./dev-server.js");
 				const viteServer = await createViteHandler(router, app, serveConfig);
 				const handler = eventHandler(async (event) => {
+					const originalURL = event.node.req.url;
+					let base = join(app.config.server.baseURL ?? "/", router.base);
+					// @ts-expect-error _skip_transform is a private property
+					event.node.req._skip_transform = !originalURL.startsWith(base);
+
 					const { default: handler } = await viteServer.ssrLoadModule(
 						handlerModule(router),
 					);


### PR DESCRIPTION
It seems to fix this specific issue. I'm just not 100% sure if it has any negative effects.

Seems to fix this issue: https://github.com/solidjs/solid-start/issues/1195

Fix based on this pr: https://github.com/nuxt/framework/pull/9602/files

Before:
<img width="745" alt="image" src="https://github.com/nksaraf/vinxi/assets/184235/5694639f-74e5-43f0-b7eb-36442d69da2c">


After:
<img width="734" alt="image" src="https://github.com/nksaraf/vinxi/assets/184235/8021ef7d-ffc0-461e-9ca5-fed41fdec30f">
