### PR TITLE
fix tests leaving behind processes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,8 @@ packages:
   - "packages/**"
   - "examples/**"
   - "frameworks/**"
-  - "test/**"
+  - "test/"
+  - "test/templates/**"
   - "docs/**"
   - 'talks/**'
   - "!**/.tmp/**"

--- a/test/helpers/create-fixture.ts
+++ b/test/helpers/create-fixture.ts
@@ -171,7 +171,7 @@ export async function createFixture(init: FixtureInit) {
 
 	let ip = "localhost";
 	let port = await getPort();
-	let proc = spawn("node", ["node_modules/vinxi/bin/cli.mjs", "start"], {
+	let proc = spawn("node", [".output/server/index.mjs"], {
 		cwd: projectDir,
 		env: {
 			...process.env,

--- a/test/helpers/create-fixture.ts
+++ b/test/helpers/create-fixture.ts
@@ -171,7 +171,7 @@ export async function createFixture(init: FixtureInit) {
 
 	let ip = "localhost";
 	let port = await getPort();
-	let proc = spawn("node", [".output/server/index.mjs"], {
+	let proc = spawn("node", ["node_modules/vinxi/bin/cli.mjs", "start"], {
 		cwd: projectDir,
 		env: {
 			...process.env,

--- a/test/helpers/create-fixture.ts
+++ b/test/helpers/create-fixture.ts
@@ -39,7 +39,7 @@ export async function createDevFixture(init: FixtureInit) {
 
 	let ip = "localhost";
 	let port = await getPort();
-	let proc = spawn("npm", ["run", "dev"], {
+	let proc = spawn("node", ["node_modules/vinxi/bin/cli.mjs", "dev"], {
 		cwd: projectDir,
 		env: {
 			...process.env,
@@ -171,7 +171,7 @@ export async function createFixture(init: FixtureInit) {
 
 	let ip = "localhost";
 	let port = await getPort();
-	let proc = spawn("npm", ["run", "start"], {
+	let proc = spawn("node", [".output/server/index.mjs"], {
 		cwd: projectDir,
 		env: {
 			...process.env,


### PR DESCRIPTION
This fixes two things.

### Too many symbolic links
pnpm scanning `test/.fixtures` and complaining about too many symbolic links.
Adding `!**/.fixtures/**` to pnpm-workspace did not work so I added `/test` and `/test/templates/**` instead.

### Test runs leaving behind processes
`proc.kill()` not terminating process. To work around this scripts are now started with node.
Either there is a bug in npm or something is wrong here.