### PR TITLE
fix: server preset defined in app config not working

### DIFF
--- a/.changeset/sour-mayflies-divide.md
+++ b/.changeset/sour-mayflies-divide.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: preset always node-server because of cli default

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -197,16 +197,7 @@ const command = defineCommand({
 			async run({ args }) {
 				const configFile = args.config;
 				globalThis.MANIFEST = {};
-				const { log, c } = await import("../lib/logger.js");
-				args.preset ??=
-					process.env.TARGET ??
-					process.env.PRESET ??
-					process.env.SERVER_PRESET ??
-					process.env.SERVER_TARGET ??
-					process.env.NITRO_PRESET ??
-					process.env.NITRO_TARGET ??
-					(process.versions.bun !== undefined ? "bun" : "node-server");
-
+				const { log, c } = await import("../lib/logger.js");					
 				log(c.dim(c.yellow(packageJson.version)));
 				const { loadApp } = await import("../lib/load-app.js");
 				const app = await loadApp(configFile, args);

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -78,7 +78,8 @@ export async function createBuild(app, buildConfig) {
 			process.env.SERVER_TARGET ??
 			process.env.NITRO_PRESET ??
 			process.env.NITRO_TARGET ??
-			app.config.server.preset,
+			app.config.server.preset ??
+			(process.versions.bun !== undefined ? "bun" : "node-server"),
 		alias: {
 			/**
 			 * These


### PR DESCRIPTION
https://github.com/solidjs/solid-start/issues/1208

on build the cli determines the preset without checking the app config.

Oh... just noticed that for dev the preset is also determined in the cli. Should it be moved back to the cli for build?
But then you would have to do it again in `createBuild` to cover this I guess. 🤔 

https://github.com/nksaraf/vinxi/blob/16814e6ec17c3fd4b06110191ce919845caecfa0/packages/vinxi/lib/app.js#L176-L179