### PR TITLE
fix: css asset href is relative

### DIFF
--- a/.changeset/three-trainers-fetch.md
+++ b/.changeset/three-trainers-fetch.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: css asset href is relative

--- a/packages/vinxi/lib/manifest/prod-server-manifest.js
+++ b/packages/vinxi/lib/manifest/prod-server-manifest.js
@@ -14,7 +14,7 @@ function createHtmlTagsForAssets(router, app, assets) {
 		.map((asset) => ({
 			tag: "link",
 			attrs: {
-				href: joinURL(app.config.server.baseURL ?? "", router.base, asset),
+				href: joinURL(app.config.server.baseURL ?? "/", router.base, asset),
 				key: join(app.config.server.baseURL ?? "", router.base, asset),
 				...(asset.endsWith(".css")
 					? { rel: "stylesheet", precendence: "high" }


### PR DESCRIPTION
Solid-Start docs build would not load css.

We have to pass a `/` to `joinURL` when no baseURL is defined otherwise we end up with relative paths even if router.base is `/`.

The first arg of `joinURL` is the base.
https://github.com/unjs/ufo/blob/8638f512e3cd982699c9ccc6a3d8f6f010f4a35a/src/utils.ts#L178-L179

Did not touch the `key` prop as I am not sure about its usage.
