### PR TITLE
findAssetsInViteManifest: Prevent recursive parsing of same ids

### DIFF
--- a/.changeset/famous-shrimps-switch.md
+++ b/.changeset/famous-shrimps-switch.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+findAssetsInViteManifest: Prevent recursive parsing of same ids

--- a/.changeset/spicy-keys-matter.md
+++ b/.changeset/spicy-keys-matter.md
@@ -1,5 +1,0 @@
----
-"vinxi": patch
----
-
-Prevent recursion in Vite's manifest parsing

--- a/.changeset/spicy-keys-matter.md
+++ b/.changeset/spicy-keys-matter.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Prevent recursion in Vite's manifest parsing

--- a/packages/vinxi/lib/manifest/vite-manifest.js
+++ b/packages/vinxi/lib/manifest/vite-manifest.js
@@ -9,10 +9,16 @@
  * @returns Array of asset URLs
  */
 const findAssetsInViteManifest = (manifest, id, assetMap = new Map()) => {
+	const stack = [];
+
 	/**
 	 * @param {string} id
 	 */
 	function traverse(id) {
+		if (stack.includes(id)) {
+			return [];
+		}
+
 		const cached = assetMap.get(id);
 		if (cached) {
 			return cached;
@@ -21,6 +27,9 @@ const findAssetsInViteManifest = (manifest, id, assetMap = new Map()) => {
 		if (!chunk) {
 			return [];
 		}
+
+		stack.push(id);
+
 		const assets = [
 			...(chunk.assets || []),
 			...(chunk.css || []),
@@ -30,6 +39,9 @@ const findAssetsInViteManifest = (manifest, id, assetMap = new Map()) => {
 		const all = [...assets, ...imports].filter(Boolean);
 		all.push(chunk.file);
 		assetMap.set(id, all);
+
+		stack.pop();
+
 		return Array.from(new Set(all));
 	}
 	return traverse(id);


### PR DESCRIPTION
Introduce stack-tracing, which doesn't allow code to dig into the same
branches again and again.

It was a problem in case when couple of "ids" in manifest reference each
other.
