### PR TITLE
fix: add types to @vinxi/react pacakge.json

### DIFF
--- a/.changeset/fifty-dodos-sort.md
+++ b/.changeset/fifty-dodos-sort.md
@@ -1,0 +1,5 @@
+---
+"@vinxi/react": patch
+---
+
+fix: add types to @vinxi/react pacakge.json

--- a/packages/vinxi-react/package.json
+++ b/packages/vinxi-react/package.json
@@ -8,14 +8,17 @@
     "invariant.js",
     "*.d.ts"
   ],
-  "types": "./index.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./index.js"
+    ".": {
+      "import": "./index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "typesVersions": {
     "*": {
       ".": [
-        "./index.d.ts"
+        "./dist/index.d.ts"
       ]
     }
   },

--- a/packages/vinxi-react/package.json
+++ b/packages/vinxi-react/package.json
@@ -6,7 +6,7 @@
   "files": [
     "*.js",
     "invariant.js",
-    "*.d.ts"
+    "dist"
   ],
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
- feat: vinxi/http package for all the http server related utilities (vinxi/server reexports)
- Create beige-walls-train.md
- fix: Update package.json to include new types and exports
