### PR TITLE
Reexporting type CookieSerializeOptions

### DIFF
--- a/.changeset/lovely-files-push.md
+++ b/.changeset/lovely-files-push.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+feat: Reexporting type CookieSerializeOptions from 'cookie-es', used by cookie helpers

--- a/packages/vinxi/runtime/http-types.d.ts
+++ b/packages/vinxi/runtime/http-types.d.ts
@@ -34,6 +34,8 @@ import { Readable } from "node:stream";
 export type HTTPEvent = H3Event | { [HTTPEventSymbol]: H3Event };
 export type HTTPServer = App;
 
+export { CookieSerializeOptions } from 'cookie-es';
+
 export {
 	H3Error,
 	H3Event,


### PR DESCRIPTION
When creating a set cookie wrapper to define the cookie options, I had to install cookie-es to have those types.

This PR reexports CookieSerializeOptions from vinxi/server for enabling the usage of it.