### PR TITLE
Add link to community post on building a framework with vinxi

### DIFF
--- a/docs/guide/build-your-own-framework.md
+++ b/docs/guide/build-your-own-framework.md
@@ -1,3 +1,5 @@
 # Build Your Own Framework
 
 (Coming Soon)
+
+Community post on the topic: [Bullding a React Metaframework with Vinxi](https://www.brenelz.com/posts/building-a-react-metaframework-with-vinxi/)


### PR DESCRIPTION
Instead of only showing `coming soon`, also have a link to this great post for now: 

Community post on the topic: [Bullding a React Metaframework with Vinxi](https://www.brenelz.com/posts/building-a-react-metaframework-with-vinxi/)