### PR TITLE
feat: add params to h3 event object for api router

### DIFF
--- a/.changeset/two-chairs-admire.md
+++ b/.changeset/two-chairs-admire.md
@@ -1,0 +1,5 @@
+---
+"@vinxi/router": patch
+---
+
+feat: add params to h3 event object for api router

--- a/packages/vinxi-router/api-handler.js
+++ b/packages/vinxi-router/api-handler.js
@@ -7,7 +7,8 @@ const routes = [
 		...route,
 		handler: async (event, params) => {
 			const mod = await route.$handler.import();
-			return await mod.default(event, params);
+			event.context['params'] = params
+			return await mod.default(event);
 		},
 	})),
 ];
@@ -35,7 +36,9 @@ function createRouter(routes) {
 					for (let i = 0; i < route.keys.length; i++) {
 						params[route.keys[i].name] = match[i + 1];
 					}
-					return await route.handler(event, params);
+					// add params to context object
+					event.context['params'] = params
+					return await route.handler(event);
 				}
 			}
 


### PR DESCRIPTION
This adds the `params` object to the H3 `event` for the API router instead of passing it as a separate object.

Closes #242 