### PR TITLE
fix example: solid/ssr/basic - Duplicate import

### DIFF
--- a/examples/solid/ssr/basic/app/server.tsx
+++ b/examples/solid/ssr/basic/app/server.tsx
@@ -12,7 +12,6 @@ import {
 } from "solid-js/web";
 import { getManifest } from "vinxi/manifest";
 import { eventHandler } from "vinxi/http";
-import { getManifest } from "vinxi/manifest";
 
 import App from "./app";
 


### PR DESCRIPTION
This is imported twice, and breaks the example

`import { getManifest } from "vinxi/manifest"; `