### PR TITLE
fix: allow serving resource files from monorepo in dev server

### DIFF
--- a/.changeset/many-jobs-clean.md
+++ b/.changeset/many-jobs-clean.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: allow serving resource files from monorepo in dev server

--- a/packages/vinxi/lib/dev-server.js
+++ b/packages/vinxi/lib/dev-server.js
@@ -47,6 +47,7 @@ export async function createViteDevServer(config) {
  * @returns {Promise<import("vite").ViteDevServer>}
  */
 export async function createViteHandler(router, app, serveConfig) {
+	const vite = await import("vite");
 	const { getRandomPort } = await import("get-port-please");
 	const port = await getRandomPort();
 	const plugins = [
@@ -72,7 +73,10 @@ export async function createViteHandler(router, app, serveConfig) {
 		app,
 		server: {
 			fs: {
-				allow: [normalize(fileURLToPath(new URL("../", import.meta.url))), "."],
+				allow: [
+					normalize(fileURLToPath(new URL("../", import.meta.url))),
+					vite.searchForWorkspaceRoot(process.cwd()),
+				],
 			},
 			middlewareMode: true,
 			hmr: {


### PR DESCRIPTION
My project loads SVG files from another package in a monorepo, but it doesn't work in vinxi-based Solid Start.

vinxi modified `server.fs.allow` value in Vite config, but it doesn't follow the documentation to use `searchForWorkspaceRoot` method to properly allow monorepo usage: https://vitejs.dev/config/server-options.html#server-fs-allow