### PR TITLE
fix: css module hmr update

### DIFF
--- a/.changeset/silly-walls-notice.md
+++ b/.changeset/silly-walls-notice.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: css module hmr update

--- a/packages/vinxi/lib/plugins/css.js
+++ b/packages/vinxi/lib/plugins/css.js
@@ -27,7 +27,9 @@ export function css() {
 						contents: code,
 					},
 				});
-				return [];
+				return file.endsWith(".module.css")
+					? undefined
+					: [];
 			}
 		},
 		transform(code, id) {


### PR DESCRIPTION
There is an issue with hmr not working as expected for css modules.
https://github.com/solidjs/solid-start/issues/1400

## Problem

### CSS Module

Edit the css module and the styling on the counter button will disappear.
[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/edit/solidjs-solid-start-zd3fz8?file=src%2Fcomponents%2FCounter.module.css) 

This Vite plugin sends custom hmr events to update inlined css. When updating a css module the generated classes change and don't match anymore with already rendered components. 

https://github.com/nksaraf/vinxi/blob/4bddafe1b7e873ef691392ebaf7ea4f4875e39d4/packages/vinxi/lib/plugins/css.js#L22-L30

## Solution

Currently I see two ways to handle css modules.

- [In PR] Don't do full custom event handling. Allowing vite to send update event for affected files.
  - Brief FOUC during update because class names don't match. No full page reload.
- Send a full-reload event
