### PR TITLE
fix: https type def

### DIFF
--- a/.changeset/eleven-news-hear.md
+++ b/.changeset/eleven-news-hear.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: https type def

--- a/packages/vinxi/lib/app.js
+++ b/packages/vinxi/lib/app.js
@@ -12,7 +12,7 @@ import { resolveRouterConfig, routerSchema } from "./router-modes.js";
 	routers?: import("./router-modes.js").RouterSchemaInput[];
 	name?:
 	string;
-	server?: Omit<import('nitropack').NitroConfig, 'handlers' | 'devHandlers' | 'publicAssets' | 'scanDirs' | 'appConfigFiles' | 'imports' | 'virtual'>;
+	server?: Omit<import('nitropack').NitroConfig, 'handlers' | 'devHandlers' | 'publicAssets' | 'scanDirs' | 'appConfigFiles' | 'imports' | 'virtual'> & { https?: import('@vinxi/listhen').HTTPSOptions | boolean };
 	root?: string
 }} AppOptions */
 
@@ -20,7 +20,7 @@ import { resolveRouterConfig, routerSchema } from "./router-modes.js";
 	config: {
 		name: string;
 		devtools: boolean;
-		server: Omit<import('nitropack').NitroConfig, 'handlers' | 'devHandlers' | 'publicAssets' | 'scanDirs' | 'appConfigFiles' | 'imports' | 'virtual'>;
+		server: Omit<import('nitropack').NitroConfig, 'handlers' | 'devHandlers' | 'publicAssets' | 'scanDirs' | 'appConfigFiles' | 'imports' | 'virtual'> & { https?: import('@vinxi/listhen').HTTPSOptions | boolean };
 		routers: import("./router-mode.js").Router[];
 		root: string;
 	};

--- a/packages/vinxi/lib/dev-server.js
+++ b/packages/vinxi/lib/dev-server.js
@@ -7,7 +7,7 @@ import { join, normalize } from "./path.js";
 
 export * from "./router-dev-plugins.js";
 
-/** @typedef {{ force?: boolean; devtools?: boolean; port?: number; ws?: { port?: number }; https?: import('@vinxi/listhen').HTTPSOptions } | boolean} DevConfigInput */
+/** @typedef {{ force?: boolean; devtools?: boolean; port?: number; ws?: { port?: number }; https?: import('@vinxi/listhen').HTTPSOptions | boolean; }} DevConfigInput */
 /** @typedef {{ force: boolean; port: number; devtools: boolean; ws: { port: number }; https: import('@vinxi/listhen').Certificate | false; }} DevConfig */
 
 /**
@@ -82,7 +82,7 @@ export async function createViteHandler(router, app, serveConfig) {
 			hmr: {
 				port,
 			},
-			https: serveConfig.https,
+			https: serveConfig.https || undefined,
 		},
 	});
 

--- a/packages/vinxi/lib/dev-server.js
+++ b/packages/vinxi/lib/dev-server.js
@@ -8,7 +8,7 @@ import { join, normalize } from "./path.js";
 export * from "./router-dev-plugins.js";
 
 /** @typedef {{ force?: boolean; devtools?: boolean; port?: number; ws?: { port?: number }; https?: import('@vinxi/listhen').HTTPSOptions | boolean; }} DevConfigInput */
-/** @typedef {{ force: boolean; port: number; devtools: boolean; ws: { port: number }; https: import('@vinxi/listhen').Certificate | false; }} DevConfig */
+/** @typedef {{ force: boolean; port: number; devtools: boolean; ws: { port: number }; https?: import('@vinxi/listhen').Certificate; }} DevConfig */
 
 /**
  *
@@ -82,7 +82,7 @@ export async function createViteHandler(router, app, serveConfig) {
 			hmr: {
 				port,
 			},
-			https: serveConfig.https || undefined,
+			https: serveConfig.https,
 		},
 	});
 
@@ -116,7 +116,7 @@ export async function createDevServer(
 		},
 		https: https
 			? await resolveCertificate(typeof https === "object" ? https : {})
-			: false,
+			: undefined,
 	};
 
 	await app.hooks.callHook("app:dev:start", { app, serveConfig });


### PR DESCRIPTION
Fix: #280 

Including small correction. Listhen's https option is optional and defaulting to undefined works out for vite as well.