### PR TITLE
Fixed node imports incompatibility

### DIFF
--- a/.changeset/nervous-pandas-do.md
+++ b/.changeset/nervous-pandas-do.md
@@ -1,0 +1,6 @@
+---
+"@vinxi/react-server": patch
+"vinxi": patch
+---
+
+Swapped all virtual #vinxi references to $vinxi to be compatible with node imports

--- a/examples/vanilla/trpc/app.config.js
+++ b/examples/vanilla/trpc/app.config.js
@@ -12,7 +12,7 @@ function trpcRouter({ plugins = () => [] } = {}) {
 		target: "server",
 		plugins: () => [
 			input(
-				"#vinxi/trpc/router",
+				"$vinxi/trpc/router",
 				fileURLToPath(new URL("./app/server.ts", import.meta.url)),
 			),
 		],

--- a/examples/vanilla/trpc/handler.js
+++ b/examples/vanilla/trpc/handler.js
@@ -1,4 +1,4 @@
-import appRouter from "#vinxi/trpc/router";
+import appRouter from "$vinxi/trpc/router";
 import { createHTTPHandler } from "@trpc/server/adapters/standalone";
 import { fromNodeMiddleware } from "vinxi/http";
 

--- a/examples/vanilla/trpc/trpc.d.ts
+++ b/examples/vanilla/trpc/trpc.d.ts
@@ -1,4 +1,4 @@
-declare module "#vinxi/trpc/router" {
+declare module "$vinxi/trpc/router" {
 	const x: any;
 	export default x;
 }

--- a/packages/vinxi-react-server/index.js
+++ b/packages/vinxi-react-server/index.js
@@ -10,7 +10,7 @@ function appEntry() {
 	return config("alias", {
 		resolve: {
 			alias: {
-				"#vinxi/app": join(process.cwd(), "app", "app.tsx"),
+				"$vinxi/app": join(process.cwd(), "app", "app.tsx"),
 			},
 		},
 	});
@@ -48,7 +48,7 @@ export function defineConfig() {
 					config("other", {
 						resolve: {
 							alias: {
-								"#vinxi/app/client": fileURLToPath(
+								"$vinxi/app/client": fileURLToPath(
 									new URL("./app/client.ts", import.meta.url),
 								),
 							},

--- a/packages/vinxi-react-server/rsc-handler.tsx
+++ b/packages/vinxi-react-server/rsc-handler.tsx
@@ -1,4 +1,4 @@
-import App from "#vinxi/app";
+import App from "$vinxi/app";
 import { renderAsset } from "@vinxi/react";
 import { Suspense } from "react";
 import { eventHandler } from "vinxi/http";

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -93,10 +93,10 @@ export async function createBuild(app, buildConfig) {
 		},
 		// minify: process.env.MINIFY !== "false" ?? true,
 		plugins: [
-			"#vinxi/prod-app",
+			"$vinxi/prod-app",
 			fileURLToPath(new URL("./app-fetch.js", import.meta.url)),
 			fileURLToPath(new URL("./app-manifest.js", import.meta.url)),
-			"#vinxi/chunks",
+			"$vinxi/chunks",
 			...(app.config.server.plugins ?? []),
 		],
 		buildDir: ".vinxi",
@@ -133,7 +133,7 @@ export async function createBuild(app, buildConfig) {
 						return [
 							{
 								route: router.base.length === 1 ? "/" : `${router.base}`,
-								handler: `#vinxi/spa/${router.name}`,
+								handler: `$vinxi/spa/${router.name}`,
 								middleware: true,
 							},
 						];
@@ -173,7 +173,7 @@ export async function createBuild(app, buildConfig) {
 		appConfigFiles: [],
 		imports: false,
 		virtual: {
-			"#vinxi/prod-app": () => {
+			"$vinxi/prod-app": () => {
 				const config = {
 					...app.config,
 					routers: app.config.routers.map((router) => {
@@ -242,7 +242,7 @@ export async function createBuild(app, buildConfig) {
 			...app.config.routers
 				.filter((router) => router.type === "spa")
 				.reduce((virtuals, router) => {
-					virtuals[`#vinxi/spa/${router.name}`] = () => {
+					virtuals[`$vinxi/spa/${router.name}`] = () => {
 						const indexHtml = readFileSync(
 							join(router.outDir, router.base, "index.html"),
 							"utf-8",
@@ -257,7 +257,7 @@ export async function createBuild(app, buildConfig) {
 					};
 					return virtuals;
 				}, {}),
-			"#vinxi/chunks": () => chunksServerVirtualModule()(app),
+			"$vinxi/chunks": () => chunksServerVirtualModule()(app),
 
 			...(Object.fromEntries(
 				Object.entries(app.config.server?.virtual ?? {}).map(([k, v]) => [
@@ -511,7 +511,7 @@ const routerModePlugin = {
 				[handlerModule(router)]: ({ config }) => {
 					invariant(
 						config.router.type === "client",
-						"#vinxi/handler is only supported in client mode",
+						"$vinxi/handler is only supported in client mode",
 					);
 					return `import * as mod from "${join(
 						config.router.root,
@@ -547,7 +547,7 @@ const routerModePlugin = {
 				[handlerModule(router)]: ({ config }) => {
 					invariant(
 						config.router.type === "http",
-						"#vinxi/handler is only supported in handler mode",
+						"$vinxi/handler is only supported in handler mode",
 					);
 
 					if (config.router.middleware) {

--- a/packages/vinxi/lib/path.js
+++ b/packages/vinxi/lib/path.js
@@ -13,5 +13,5 @@ export function handlerModule(
 		? isAbsolute(router.handler)
 			? router.handler
 			: join(router.root, router.handler)
-		: `#vinxi/handler/${router.name}`;
+		: `$vinxi/handler/${router.name}`;
 }

--- a/packages/vinxi/lib/router-dev-plugins.js
+++ b/packages/vinxi/lib/router-dev-plugins.js
@@ -40,7 +40,7 @@ export const ROUTER_MODE_DEV_PLUGINS = {
 				const router = config.router;
 				invariant(
 					router.handler,
-					"#vinxi/handler is only supported in handler mode",
+					"$vinxi/handler is only supported in handler mode",
 				);
 
 				if (router.middleware) {


### PR DESCRIPTION
Node has reserved `#` for [imports](https://nodejs.org/api/packages.html#subpath-imports)

>Entries in the "imports" field must always start with # to ensure they are disambiguated from external package specifiers.

This swaps it to `$`. I tested it by modifying my `node_modules` install of vinxi and my dev server worked again resolving #249.