### PR TITLE
fix: replace stylesheet precendence with fetchpriority

### DIFF
--- a/.changeset/smart-horses-film.md
+++ b/.changeset/smart-horses-film.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Replaced stylesheet `precendence` attribute with `fetchpriority`.

--- a/packages/vinxi/lib/manifest/prod-server-manifest.js
+++ b/packages/vinxi/lib/manifest/prod-server-manifest.js
@@ -22,7 +22,7 @@ function createHtmlTagsForAssets(router, app, assets) {
 				href: joinURL(app.config.server.baseURL ?? "/", router.base, asset),
 				key: join(app.config.server.baseURL ?? "", router.base, asset),
 				...(asset.endsWith(".css")
-					? { rel: "stylesheet", precendence: "high" }
+					? { rel: "stylesheet", fetchpriority: "high" }
 					: { rel: "modulepreload" }),
 			},
 		}));

--- a/packages/vinxi/lib/manifest/spa-manifest.js
+++ b/packages/vinxi/lib/manifest/spa-manifest.js
@@ -54,7 +54,7 @@ export async function createSPAManifest(config, bundle, format) {
 							href: join(config.base, asset),
 							key: join(config.base, asset),
 							rel: "stylesheet",
-							precendence: "high",
+							fetchpriority: "high",
 						},
 					})),
 			};
@@ -76,7 +76,7 @@ export async function createSPAManifest(config, bundle, format) {
 		// 				href: join(config.base, asset),
 		// 				key: join(config.base, asset),
 		// 				rel: "stylesheet",
-		// 				precendence: "high",
+		// 				fetchpriority: "high",
 		// 			},
 		// 		})),
 		// };


### PR DESCRIPTION
`precendence` isn't valid html and in React it would be called `precedence` 😅🙈. The html compatible equivalent is `fetchpriority`.