### PR TITLE
Fix style order in dev mode

### DIFF
--- a/.changeset/giant-dolphins-exist.md
+++ b/.changeset/giant-dolphins-exist.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: style order in dev mode

--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -117,7 +117,7 @@ async function findDeps(vite, node, deps, ssr) {
 	} else if (!ssr) {
 		for (const { url } of node.importedModules) {
 			if (node.staticImportedUrls?.size) {
-				branches.push(add_by_url(node.url, ssr));
+				await add_by_url(node.url, ssr);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the following bug: https://github.com/solidjs/solid-start/issues/1478

I understand that it was an attempt to avoid FOUC, but it should be done better, because resulting style order is wrong. Also it eliminates duplication of styles in dev mode.