### PR TITLE
fix: always run vanilla vite hot css updates after vinxis custom updates

### DIFF
--- a/.changeset/metal-elephants-worry.md
+++ b/.changeset/metal-elephants-worry.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Vinxi now always runs Vite vanilla css hot updates, after Vinxis custom update logic. In particular this fixes hot updates for css files imported via `?url`.

--- a/packages/vinxi/lib/plugins/css.js
+++ b/packages/vinxi/lib/plugins/css.js
@@ -27,9 +27,6 @@ export function css() {
 						contents: code,
 					},
 				});
-				return file.endsWith(".module.css")
-					? undefined
-					: [];
 			}
 		},
 		transform(code, id) {


### PR DESCRIPTION
## IS

Vinxis custom hot css update suppresses updates of css files imported with `?url`.

## SHOULD

Css files imported with `?url` should be hot updated properly. 

## Fix info

The suppression of vite hot css updates (by returning `[]`) already had to be disabled for css modules, so I thought why not just remove the suppression at all... Do you know why the vanilla vite hot css updates were disabled by returning `[]` 😅? If they were disabled for some good reason I can search for a different fix 😉.

## Reproduction

URL: https://stackblitz.com/edit/github-holpn7?file=src%2Froutes%2Findex.tsx,src%2Froutes%2Findex.css

1. Run `npm run dev`
2. Open `./src/routes/index.css` and change the background-color
3. Result: The css is not hot updated


