### PR TITLE
feat: export `lib/vite-dev` for external use

### DIFF
--- a/packages/vinxi/package.json
+++ b/packages/vinxi/package.json
@@ -104,6 +104,9 @@
     },
     "./types/server": {
       "types": "./types/server.d.ts"
+    },
+    "./lib/vite-dev": {
+      "types": "./dist/types/lib/vite-dev.d.ts"
     }
   },
   "typesVersions": {
@@ -161,6 +164,9 @@
       ],
       "manifest": [
         "./dist/types/runtime/manifest.d.ts"
+      ],
+      "lib/vite-dev": [
+        "./dist/types/lib/vite-dev.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Export the `lib/vite-dev` type to facilitate users to import the types defined in it.

For example, to provide convenience for defining user-configured types in the solid-start project.

https://github.com/solidjs/solid-start/blob/914647c9d122cfb3dd974d904012a8eb38898322/packages/start/config/index.d.ts#L2
