### PR TITLE
server functions: allow get requests

### DIFF
--- a/.changeset/tiny-items-report.md
+++ b/.changeset/tiny-items-report.md
@@ -1,0 +1,6 @@
+---
+"@vinxi/server-functions": patch
+"vinxi": patch
+---
+
+server functions: allow get requests

--- a/packages/vinxi-server-functions/server-handler.js
+++ b/packages/vinxi-server-functions/server-handler.js
@@ -3,9 +3,10 @@ import { eventHandler, getHeader, readBody, setHeader } from "vinxi/http";
 import invariant from "vinxi/lib/invariant";
 import { getManifest } from "vinxi/manifest";
 
-export async function handleServerAction(event) {
-	invariant(event.method === "POST", "Invalid method");
+const allowedMethods = ["POST", "GET"];
 
+export async function handleServerAction(event) {
+	invariant(allowedMethods.includes(event.method), "Invalid method");
 	const serverReference = getHeader(event, "server-action");
 	if (serverReference) {
 		invariant(typeof serverReference === "string", "Invalid server action");
@@ -14,7 +15,10 @@ export async function handleServerAction(event) {
 		const action = (
 			await getManifest(import.meta.env.ROUTER_NAME).chunks[filepath].import()
 		)[name];
-		const json = await readBody(event);
+		let json = {};
+		if (event.method === "POST") {
+			json = await readBody(event);
+		} 
 		const result = action.apply(null, json);
 		try {
 			// Wait for any mutations


### PR DESCRIPTION
```ts
	const get1 = async () => {
		const res = await fetch("http://localhost:3000/_server", {
			method: "GET",
			headers: {
				"Server-Action":
					"/Users/or/Desktop/vinxi/examples/solid/ssr/basic/app/getActions.tsx#getAction",
			},
		});
		const data = await res.json();
		console.log(data);
	};
```

this is now valid, i was also trying to make this valid:

```ts

	const get2 = async () => {
		const res = await fetch(
			`http://localhost:3000/_server?serveract=${encodeURIComponent(
				"/Users/or/Desktop/vinxi/examples/solid/ssr/basic/app/getActions.tsx#getAction",
			)}`,
			{
				method: "GET",
			},
		);
		const data = await res.json();
		console.log(data);
	};
```

but the codebase was so messy and untyped i barely could have got anything moving. this is useful for an open graph library we are building as a part of solid mediakit.

i'm aware that params don't exist when making a get request and that is fine we don't need this rn, we just need the base working.
	