### PR TITLE
Add ./dist/types exports to package.json

### DIFF
--- a/.changeset/spicy-apples-protect.md
+++ b/.changeset/spicy-apples-protect.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Add ./dist/types exports to package.json

--- a/packages/vinxi/package.json
+++ b/packages/vinxi/package.json
@@ -29,6 +29,9 @@
       "import": "./lib/dev-server.js",
       "types": "./dist/types/lib/dev-server.d.ts"
     },
+    "./dist/types/*": {
+      "types": "./dist/types/*.d.ts"
+    },
     "./stack": {
       "import": "./stack/index.js"
     },
@@ -113,6 +116,9 @@
       ],
       "dev-server": [
         "./dist/types/lib/dev-server.d.ts"
+      ],
+      "dist/types/*": [
+        "./dist/types/*.d.ts"
       ],
       "server": [
         "./runtime/server-types.d.ts"


### PR DESCRIPTION
Solid Start imports `CustomizableConfig` from `vinxi/dist/types/lib/vite-dev`. With `moduleResolution: "node"` this works fine, but `moduleResolution: "bundler"` (which is now recommended) requires all subpath exports to be listed in `exports` and (for posterity) `typesVersions`, so I've added wildcard entries for `./dist/types/*`.

This will fix the Vite part of https://github.com/solidjs/solid-start/issues/1505