### PR TITLE
Fix style collection to not collect from dynamic deps

### DIFF
--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -111,9 +111,12 @@ async function findDeps(vite, node, deps, ssr) {
 		//   node.ssrTransformResult.dynamicDeps.forEach(url => branches.push(add_by_url(url)));
 		// }
 	} else if (!ssr) {
-		node.importedModules.forEach((node) =>
-			branches.push(add_by_url(node.url, ssr)),
-		);
+		node.importedModules.forEach((node) => {
+			// only include statically imported dependencies
+			if (node.staticImportedUrls?.size) {
+				branches.push(add_by_url(node.url, ssr));
+			}
+		});
 	}
 
 	await Promise.all(branches);


### PR DESCRIPTION
This makes Vinxi stop collecting styles from dynamic dependencies, which triggers Vite transforms per each dependency and drops dev performance significantly if done on modules that contain a lot of dynamic dependencies, potentially because of using `import.meta.glob()`.