### PR TITLE
fix: use the proper url to walk through modules during dev style coll…

### DIFF
--- a/.changeset/lazy-glasses-hope.md
+++ b/.changeset/lazy-glasses-hope.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Fixed a bug in the dev style collection that resulted in flashes of unstyled content.

--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -116,9 +116,7 @@ async function findDeps(vite, node, deps, ssr) {
 		// }
 	} else if (!ssr) {
 		for (const { url } of node.importedModules) {
-			if (node.staticImportedUrls?.size) {
-				await add_by_url(node.url, ssr);
-			}
+			await add_by_url(url, ssr);
 		}
 	}
 }


### PR DESCRIPTION
## Is
We get flashes of unstyled content for any included css in dev.

## Should
There should be no foucs.

## Background
The happenings actually are much more complicated than the fix might suggest 🥴. We had a series of unfortunate events with the changes from the last release:

1. The changes from https://github.com/nksaraf/vinxi/pull/310 applied a flawed logic to detect dynamically imported modules (as far as I can tell).
2. A later merge conflict resolution introduced two "bugs":
    - 2a: https://github.com/nksaraf/vinxi/commit/00cb3d38fbc19ea3d49c656028a648da99c1450e#diff-59f5f323d1f5e2fd6f3b8f4f8275e8d7ceb138027e7faaec96719fdbd9eebc64R119 - it changed the already flawed logic to check `staticImportedUrls` on the parent node, instead of the current node of the for-loop
    - 2b: https://github.com/nksaraf/vinxi/commit/00cb3d38fbc19ea3d49c656028a648da99c1450e#diff-59f5f323d1f5e2fd6f3b8f4f8275e8d7ceb138027e7faaec96719fdbd9eebc64R120 - it used the wrong node url to walk through the modules

Since the logic for detecting dynamically imported modules was flawed from the beginning, I removed it which fixed 2a. Secondly I fixed the line that resulted in 2b.

## Follow ups
Since this undoes the changes from https://github.com/nksaraf/vinxi/pull/310 we need to discuss a better way to identify and exclude dynamically imported modules in the style collection - (..personally I am not a fan of excluding them and the resulting foucs, but if thats really the goal, then we should atleast do it properly 😅🙈)

## Videos

### Before fix

https://github.com/nksaraf/vinxi/assets/4012401/ba066aa7-989a-48a2-8ed6-5791bb07bc51

### After fix

https://github.com/nksaraf/vinxi/assets/4012401/0158d3e8-e56d-4fa1-a475-7a09eb322d44

