### PR TITLE
Fix Vinxi MDX ignoring query params

### DIFF
--- a/packages/vinxi-mdx/src/index.ts
+++ b/packages/vinxi-mdx/src/index.ts
@@ -64,8 +64,7 @@ function createPlugin(
 			transformMdx = createTransformer(root, namedImports);
 		},
 		async transform(code, id, ssr) {
-			const [path, query] = id.split("?");
-			if (/\.mdx?$/.test(path)) {
+			if (/\.mdx?$/.test(id)) {
 				if (!transformMdx)
 					throw new Error(
 						"vite-plugin-mdx: configResolved hook should be called before calling transform hook",
@@ -73,17 +72,17 @@ function createPlugin(
 
 				const mdxOptions = mergeOptions(
 					globalMdxOptions,
-					getMdxOptions?.(path),
+					getMdxOptions?.(id),
 				);
 
-				const input = new VFile({ value: code, path })
+				const input = new VFile({ value: code, path: id })
 
 				code = await transformMdx(input, { ...mdxOptions });
 				// @ts-ignore
 				const refreshResult = await reactRefresh?.transform!.call(
 					this,
 					code,
-					path + ".js",
+					id + ".js",
 					ssr,
 				);
 


### PR DESCRIPTION
Currently, Vinxi MDX transforms MDX files whether they are imported with query params or not.
Since Vinxi MDX has `enforce: "pre"`, it blocks features like [`?raw` query param](https://vitejs.dev/guide/assets.html#importing-asset-as-string) from working correctly.
This PR fixes the issue by ensuring MDX files are only transformed when there are no query params.