### PR TITLE
Fix changes from #310 to correctly collect imported CSS files

### DIFF
--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -115,8 +115,10 @@ async function findDeps(vite, node, deps, ssr) {
 		//   node.ssrTransformResult.dynamicDeps.forEach(url => branches.push(add_by_url(url)));
 		// }
 	} else if (!ssr) {
-		for (const { url } of node.importedModules) {
-			await add_by_url(url, ssr);
+		for (const module of node.importedModules) {
+			if (module.staticImportedUrls?.size || module.url.endsWith(".css")) {
+				await add_by_url(module.url, ssr);
+			}
 		}
 	}
 }


### PR DESCRIPTION
This tries to land changes from #310 (that got rolled back in #312) without re-introducing dev FOUCs.
The problem was that even CSS imports don't have `staticImportedUrls`, which makes those files not collected as a dependency.
This PR adds a small check to see if nodes are CSS modules or not, to ensure all CSS imports are collected.