### PR TITLE
[WIP] fix: wait for hydration via react effect

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -44,6 +44,7 @@ testDevAndProd("basic", ({ createFixture }) => {
 	test("hydrates", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=content]")).toBe(
 			prettyHtml(`<h1 data-test-id="content">Hello from Vinxi</h1>`),

--- a/test/fs-router.test.ts
+++ b/test/fs-router.test.ts
@@ -60,6 +60,7 @@ testDevAndProd("fs-router", ({ createFixture }) => {
 	test("hydrates", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=title]")).toBe(
 			prettyHtml(`<h1 data-test-id="title">Vinxi Home</h1>`),
@@ -76,7 +77,7 @@ testDevAndProd("fs-router", ({ createFixture }) => {
 
 		await app.clickElement("a[href='/hello']");
 		await app.waitForURL("/hello");
-		await new Promise((r) => setTimeout(r, 1000));
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=title]")).toBe(
 			prettyHtml(`<h1 data-test-id="title">Hello from Vinxi</h1>`),
@@ -87,7 +88,7 @@ testDevAndProd("fs-router", ({ createFixture }) => {
 
 		await app.clickElement("a[href='/']");
 		await app.waitForURL("/");
-		await new Promise((r) => setTimeout(r, 2000));
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=title]")).toBe(
 			prettyHtml(`<h1 data-test-id="title">Vinxi Home</h1>`),

--- a/test/helpers/create-fixture.ts
+++ b/test/helpers/create-fixture.ts
@@ -133,8 +133,10 @@ export async function createDevFixture(init: FixtureInit) {
 					await fse.remove(path.join(projectDir, filename));
 				} else {
 					await fse.writeFile(path.join(projectDir, filename), prevValue);
+					await new Promise((r) => setTimeout(r, 2000));
 				}
 			}
+			cache.clear();
 			// await fse.remove(projectDir);
 			// projectDir = await createFixtureProject(init);
 		},
@@ -157,6 +159,7 @@ export async function createDevFixture(init: FixtureInit) {
 			}
 
 			await fse.writeFile(path.join(projectDir, filename), content);
+			await new Promise((r) => setTimeout(r, 2000));
 		},
 		createServer: async () => {
 			return {

--- a/test/hmr.test.ts
+++ b/test/hmr.test.ts
@@ -74,8 +74,6 @@ test.describe("hmr", () => {
 			}`,
 		);
 
-		await new Promise((r) => setTimeout(r, 1000));
-
 		res = await fixture.requestDocument("/");
 		expect(res.status).toBe(200);
 		expect(res.headers.get("Content-Type")).toBe("text/html");
@@ -87,6 +85,7 @@ test.describe("hmr", () => {
 	test("client hmr", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=content]")).toBe(
 			prettyHtml(`<h1 data-test-id="content">Hello from Vinxi</h1>`),
@@ -118,8 +117,6 @@ test.describe("hmr", () => {
 			}`,
 		);
 
-		await new Promise((r) => setTimeout(r, 1000));
-
 		expect(await app.getHtml("[data-test-id=button]")).toBe(
 			prettyHtml(`<button data-test-id="button">Click me again</button>`),
 		);
@@ -138,8 +135,6 @@ test.describe("hmr", () => {
 			}`,
 		);
 
-		await new Promise((r) => setTimeout(r, 1000));
-
 		res = await fixture.requestDocument("/api/hello");
 		expect(res.status).toBe(200);
 		expect(res.headers.get("Content-Type")).toBe("text/html");
@@ -151,8 +146,6 @@ test.describe("hmr", () => {
 				return "Hello new";
 			}`,
 		);
-
-		await new Promise((r) => setTimeout(r, 2000));
 
 		res = await fixture.requestDocument("/api/new");
 		expect(res.status).toBe(200);

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -5,12 +5,11 @@ const config: PlaywrightTestConfig = {
 	testDir: ".",
 	testMatch: ["**/*.test.ts"],
 	fullyParallel: false,
-	timeout: process.env.CI ? 120_000 : 30_000, // 2 minutes in CI, 30 seconds locally
+	timeout: process.env.CI ? 360_000 : 30_000, // 5 minutes in CI, 30 seconds locally
 	expect: {
 		timeout: 5_000, // 5 second retries for assertions
 	},
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
 	reporter: process.env.CI
 		? "github"
 		: [["html", { open: process.env.TEST_REPORT ? "always" : "none" }]],

--- a/test/rsc.test.ts
+++ b/test/rsc.test.ts
@@ -36,6 +36,7 @@ test.describe("rsc", () => {
 	test("spa", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		expect(await app.getHtml("[data-test-id=title]")).toBe(
 			prettyHtml(`<h1 data-test-id="title">Hello from Vinxi</h1>`),

--- a/test/srv-fn.test.ts
+++ b/test/srv-fn.test.ts
@@ -32,6 +32,7 @@ testDevAndProd("srv-fn", ({ createFixture }) => {
 	test("spa", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		let responses = app.collectResponses();
 		await app.clickElement("[data-test-id=button]");

--- a/test/templates/react-rsc/app/Counter.tsx
+++ b/test/templates/react-rsc/app/Counter.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function Counter({ onChange }) {
+	useEffect(() => {
+		document.documentElement.dataset.ready = "";
+		return () => {
+			document.documentElement.dataset.ready = null;
+		}
+	}, []);
 	const [count, setCount] = useState(0);
 	return (
 		<button

--- a/test/templates/react-srv-fn/app/App.tsx
+++ b/test/templates/react-srv-fn/app/App.tsx
@@ -1,9 +1,18 @@
+import React, { useEffect } from "react";
+
 async function greetServer(name: string) {
 	"use server";
 	console.log(`Hi, server. My name is ${name}.`);
 }
 
 export function App() {
+	useEffect(() => {
+		document.documentElement.dataset.ready = "";
+		return () => {
+			document.documentElement.dataset.ready = null;
+		}
+	}, []);
+
 	return (
 		<div>
 			<button onClick={() => greetServer("client")} data-test-id="button">

--- a/test/templates/react-ssr-fs/app/app.tsx
+++ b/test/templates/react-ssr-fs/app/app.tsx
@@ -1,10 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { Counter } from "./Counter";
 import "./style.css";
 
 export default function App({ assets, children }) {
-	const [count, setCount] = React.useState(0);
+	useEffect(() => {
+		document.documentElement.dataset.ready = "";
+		return () => {
+			document.documentElement.dataset.ready = null;
+		}
+	}, []);
+
 	return (
 		<html lang="en">
 			<head>

--- a/test/templates/react-to-web-request/app/App.tsx
+++ b/test/templates/react-to-web-request/app/App.tsx
@@ -1,9 +1,18 @@
+import React, { useEffect } from "react";
+
 async function getData() {
 	"use server";
 	console.log(`I have not been blocked.`);
 }
 
 export function App() {
+	useEffect(() => {
+		document.documentElement.dataset.ready = "";
+		return () => {
+			document.documentElement.dataset.ready = null;
+		}
+	}, []);
+
 	return (
 		<div>
 			<button onClick={() => getData()} data-test-id="button">

--- a/test/templates/react/app/root.tsx
+++ b/test/templates/react/app/root.tsx
@@ -1,8 +1,15 @@
 import React from "react";
-
+import { useEffect } from "react";
 import { Counter } from "./Counter";
 
 export default function App({ assets }) {
+	useEffect(() => {
+		document.documentElement.dataset.ready = "";
+		return () => {
+			document.documentElement.dataset.ready = null;
+		}
+	}, []);
+
 	return (
 		<html lang="en">
 			<head>

--- a/test/to-web-request.test.ts
+++ b/test/to-web-request.test.ts
@@ -32,6 +32,7 @@ testDevAndProd("toWebRequest", ({ createFixture }) => {
 	test("readBody call after toWebRequest does not block", async ({ page }) => {
 		let app = new PlaywrightFixture(appFixture, page);
 		await app.goto("/", true);
+		await app.isReady();
 
 		const el = await page.$("[data-test-id=button]");
 		await el.click();


### PR DESCRIPTION
This PR tries to reduce the flakiness of the tests as much as possible. But it isn't perfect: sometimes the page hydration just fails for unknown reasons, especially on Windows. The new `isReady` check tries to recover from hydration fails, by reloading the page, which seems to work pretty solidly. Longterm though we should think about rewriting a lot of the tests, especially those related to HMR & `fixture.updateFile`.

I ran the updated tests countless times with force-pushes and so far got zero fails with the latest version.