### PR TITLE
feat: add comment directive to ignore style collection

### DIFF
--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -10,6 +10,8 @@ const skip = [
 	"@vinxi/react-server-dom/runtime",
 ];
 
+const IGNORE_COMMENT_REGEXP = /^(?:(?:\/\/.+\n)|(?:\/\*.+\*\/)|\s)*(\/\/ *@vinxi-ignore-style-collection\n)/;
+
 async function getViteModuleNode(vite, file, ssr) {
 	if (file.startsWith("node:") || isBuiltin(file)) {
 		return null;
@@ -96,7 +98,10 @@ async function findDeps(vite, node, deps, ssr) {
 		}
 	}
 
-	if (node.url.endsWith(".css")) {
+	if (
+		node.url.endsWith(".css") ||
+		node.transformResult?.map?.sourcesContent.some((code) => code.match(IGNORE_COMMENT_REGEXP))
+	) {
 		return;
 	}
 	if (ssr && node.ssrTransformResult) {


### PR DESCRIPTION
Continued from #316, cc @katywings

This PR adds `// @vinxi-ignore-style-collection` directive to ignore a module from the style collection.
The directive only works when added at the top of the file, before having any meaningful code beside comments and whitespaces.