### PR TITLE
fix automatic deployment detection by not forcing node preset

### DIFF
--- a/.changeset/five-wasps-love.md
+++ b/.changeset/five-wasps-love.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix automatic deployment detection by not forcing node preset

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -76,7 +76,7 @@ export async function createBuild(app, buildConfig) {
 			process.env.NITRO_PRESET ??
 			process.env.NITRO_TARGET ??
 			app.config.server.preset ??
-			(process.versions.bun !== undefined ? "bun" : "node-server"),
+			(process.versions.bun !== undefined ? "bun" : undefined),
 		alias: {
 			/**
 			 * These


### PR DESCRIPTION
Deployment detection for platforms like Netlify and Vercel were not working because we set a preset even when the user wasn't. I've removed this but kept the Bun clause in. That shouldn't impact the other platforms I think.