### PR TITLE
fix: vite plugin assets order

### DIFF
--- a/.changeset/sharp-kiwis-jump.md
+++ b/.changeset/sharp-kiwis-jump.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: vite plugin assets order


### PR DESCRIPTION
Assets order returned by dev-server-manifest is not correct. This causes `vite:react-refresh` preamble script to be inserted after the client runtime. Causing an occasional error.  closes #272

```
Error: @vitejs/plugin-react can't detect preamble. Something is wrong. See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201
    at app.tsx:33:5
```

### Before sort

```js
[  
  {
    name: 'vite:react-refresh',
    enforce: 'pre',
    config: [Function: config],
    resolveId: [Function: resolveId],
    load: [Function: load],
    transformIndexHtml: [Function: transformIndexHtml]
  },
  {
    name: 'vinxi:inject-client-runtime',
    configResolved: [Function: configResolved],
    apply: 'serve',
    transformIndexHtml: [Function: transformIndexHtml]
  },
]
```

### After sort

```js
[
  {
    name: 'vinxi:inject-client-runtime',
    configResolved: [Function: configResolved],
    apply: 'serve',
    transformIndexHtml: [Function: transformIndexHtml]
  },
  {
    name: 'vite:react-refresh',
    enforce: 'pre',
    config: [Function: config],
    resolveId: [Function: resolveId],
    load: [Function: load],
    transformIndexHtml: [Function: transformIndexHtml]
  }
]
```

## Reproduction

1. pnpm -F react-ssr-basic dev
2. Open in Firefox (Chrome works too but you need to refresh a lot of times to see the error occasionaly)
3. Refresh Browser
4. Counter doesn't work and the error mentioned above is shown on the console

## Solution

~Don't sort the plugins taken from the vite server config. Looking at Vite's implementation they should already be filtered and sorted.~ Correction: Vinxi currently sorts on the hook's order but the result is wrong.

Use [Vite's sorting logic](https://github.com/vitejs/vite/blob/167006e74751a66776f4f48316262449b19bf186/packages/vite/src/node/plugins/html.ts#L1253-L1264) to ensure things are in the right order.