### PR TITLE
chore: remove broken links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,6 @@ export default defineConfig({
 		sidebar: [
 			{
 				text: "Guide",
-				link: "/guide",
 				items: [
 					{ text: "Why Vinxi", link: "/guide/why-vinxi" },
 					{ text: "Get Started", link: "/guide/getting-started" },
@@ -49,7 +48,6 @@ export default defineConfig({
 			},
 			{
 				text: "APIs",
-				link: "/api",
 				items: [
 					{ text: "App API", link: "/api/app" },
 					{


### PR DESCRIPTION
## Motivation

- Notice that the links to https://vinxi.vercel.app/guide.html and https://vinxi.vercel.app/api.html on the official website are broken.