### PR TITLE
fix: hash chunks with djb2

### DIFF
--- a/.changeset/tough-timers-admire.md
+++ b/.changeset/tough-timers-admire.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: hash chunks with djb2

--- a/packages/vinxi/lib/chunks.js
+++ b/packages/vinxi/lib/chunks.js
@@ -1,7 +1,7 @@
 import { readFileSync } from "fs";
-import { join } from "vinxi/lib/path";
 
 import { viteManifestPath } from "./manifest-path.js";
+import { join } from "./path.js";
 
 const CHUNK_PREFIX = "c_";
 
@@ -57,19 +57,31 @@ export const chunksServerVirtualModule =
 		`;
 	};
 
+const hashes = new Map();
+const regexReturnCharacters = /\r/g;
+
 /**
+ * djb2 hashing
  *
- * @param {string} str
- * @returns
+ * @param {string} input
+ * @returns {string}
+ *
+ * Source: https://github.com/sveltejs/svelte/blob/0203eb319b5d86138236158e3ae6ecf29e26864c/packages/svelte/src/utils.js#L7
+ * Source License: MIT
  */
-export function hash(str) {
-	let hash = 0;
+export function hash(input) {
+	const cachedResult = hashes.get(input);
+	if (cachedResult) return cachedResult;
 
-	for (let i = 0; i < str.length; i++) {
-		hash += str.charCodeAt(i);
-	}
+	let str = input.replace(regexReturnCharacters, "");
+	let hash = 5381;
+	let i = str.length;
 
-	return hash;
+	while (i--) hash = ((hash << 5) - hash) ^ str.charCodeAt(i);
+	const result = (hash >>> 0).toString(36);
+	hashes.set(input, result);
+
+	return result;
 }
 
 /**

--- a/packages/vinxi/lib/chunks.test.js
+++ b/packages/vinxi/lib/chunks.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { hash } from "./chunks";
+
+describe("hash", () => {
+	it("should create different hashes for abc and cba", () => {
+		expect(hash("abc")).not.toEqual(hash("cba"));
+	});
+});


### PR DESCRIPTION
This replaces the hashing function with an actual hash algorithm (djb2).
The original code comes from https://github.com/sveltejs/svelte/blob/0203eb319b5d86138236158e3ae6ecf29e26864c/packages/svelte/src/utils.js#L7. 

I also added a Map to avoid duplicate hashing of earlier inputs.

## Comparison of the hashes
```ts
[
  { value: 'abc', hashNew: '2nhvp3', hashOld: 294 },
  { value: 'cba', hashNew: '2nhu0v', hashOld: 294 },
  {
    value: '/app/src/server/project.js',
    hashNew: '1gxub3t',
    hashOld: 2526
  },
  {
    value: '/app/src/project/server.js',
    hashNew: '1dkakbx',
    hashOld: 2526
  }
]
```

## Performance

Benchmark wise I didn't do a lot. But the few builds I did on a large project look okay:

|        | SSR   | Client | Server-fns |
| ------ | ----- | ------ | ---------- |
| New 1  | 8.93s | 12.84s | 9.40s      |
| New 2  | 8.73s | 13.38s | 9.72s      |
| New 3  | 8.75s | 13.06s | 9.43s      |
| Median | 8.73s | 13.06s | 9.43s      |

|        | SSR   | Client | Server-fns |
| ------ | ----- | ------ | ---------- |
| Old 1  | 9.28s | 13.80s | 9.43s      |
| Old 2  | 9.13s | 13.23s | 9.29s      |
| Old 3  | 8.87s | 13.88s | 9.65s      |
| Median | 9.13s | 13.80s | 9.43s      |