### PR TITLE
Update path-to-regexp and don't override the params on the routes handler

### DIFF
--- a/.changeset/four-guests-deny.md
+++ b/.changeset/four-guests-deny.md
@@ -1,0 +1,5 @@
+---
+"@vinxi/router": patch
+---
+
+Update path-to-regexp and don't override the params on the routes handler

--- a/packages/vinxi-router/api-handler.js
+++ b/packages/vinxi-router/api-handler.js
@@ -14,7 +14,7 @@ const routes = [
 
 function createRouter(routes) {
 	const builtRoutes = routes.map((route) => {
-		const matcher = match(route.path)
+		const matcher = match(route.path);
 		return {
 			...route,
 			matcher,
@@ -30,8 +30,8 @@ function createRouter(routes) {
 				const match = route.matcher(path)
 				if (match) {
 					// add params to context object
-					setContext(event, 'params', { ...match.params })
-					return await route.handler(event)
+					setContext(event, 'params', { ...match.params });
+					return await route.handler(event);
 				}
 			}
 

--- a/packages/vinxi-router/api.js
+++ b/packages/vinxi-router/api.js
@@ -17,7 +17,7 @@ class APIFileSystemRouter extends BaseFileSystemRouter {
 			.replace(/index$/, "")
 			.replace(/\[([^\/]+)\]/g, (_, m) => {
 				if (m.length > 3 && m.startsWith("...")) {
-					return `:${m.slice(3)}*`;
+					return `*${m.slice(3)}`;
 				}
 				if (m.length > 2 && m.startsWith("[") && m.endsWith("]")) {
 					return `:${m.slice(1, -1)}?`;

--- a/packages/vinxi-router/package.json
+++ b/packages/vinxi-router/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "path-to-regexp": "^6.2.1",
+    "path-to-regexp": "^8.0.0",
     "vite-tsconfig-paths": "^4.2.0"
   },
   "repository": {


### PR DESCRIPTION
The context.params is being overridden here

https://github.com/nksaraf/vinxi/blob/cb790e1ff1d4062b96174935891af6dbccdc50cb/packages/vinxi-router/api-handler.js#L5-L14
