### PR TITLE
fix(vinxi): remove js assets from router targeting server with type http

### DIFF
--- a/.changeset/metal-files-itch.md
+++ b/.changeset/metal-files-itch.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Remove js bundles from the public directory for routers with a type of 'http' and targetting 'server'

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -317,7 +317,7 @@ export async function createBuild(app, buildConfig) {
 	await mkdir(join(nitro.options.output.publicDir), { recursive: true });
 	await copyPublicAssets(nitro);
 
-	// remove js files from assets
+	// remove js files from assets for 'http' routers targetting 'server'
 	// https://github.com/nksaraf/vinxi/issues/363
 	for (const router of app.config.routers.filter(
 		(r) => r.type === "http" && r.target === "server",


### PR DESCRIPTION
Removes the js bundles from the "public/assets" folder for routers that have
- type = 'http'
- target = 'server'

Fixes #363 