### PR TITLE
Re-export useBase from H3

### DIFF
--- a/.changeset/silent-rockets-live.md
+++ b/.changeset/silent-rockets-live.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Re-export useBase

--- a/packages/vinxi/runtime/http-types.d.ts
+++ b/packages/vinxi/runtime/http-types.d.ts
@@ -74,6 +74,7 @@ export {
 	splitCookiesString,
 	sanitizeStatusCode,
 	sanitizeStatusMessage,
+	useBase,
 	type AddRouteShortcuts,
 	type App,
 	type AppOptions,

--- a/packages/vinxi/runtime/http.js
+++ b/packages/vinxi/runtime/http.js
@@ -61,6 +61,7 @@ import {
 	setResponseStatus as _setResponseStatus,
 	unsealSession as _unsealSession,
 	updateSession as _updateSession,
+	useBase as _useBase,
 	useSession as _useSession,
 	writeEarlyHints as _writeEarlyHints,
 } from "h3";
@@ -279,6 +280,7 @@ export const parseCookies = createWrapperFunction(_parseCookies);
 export const getCookie = createWrapperFunction(_getCookie);
 export const setCookie = createWrapperFunction(_setCookie);
 export const deleteCookie = createWrapperFunction(_deleteCookie);
+export const useBase = createWrapperFunction(_useBase);
 export const useSession = createWrapperFunction(_useSession);
 export const getSession = createWrapperFunction(_getSession);
 export const updateSession = createWrapperFunction(_updateSession);


### PR DESCRIPTION
`useBase` is a useful H3 utility for creating nested routers. Having it available directly from Vinxi would be useful.

https://h3.unjs.io/guide/router#nested-routers

> You can nest routers to create a tree of routers. This is useful to split your application into multiple parts like the API and the website.
> ```js
> websiteRouter.use("/api/**", useBase("/api", apiRouter.handler));
> ```
