### PR TITLE
fix Asset type

### DIFF
--- a/.changeset/grumpy-masks-accept.md
+++ b/.changeset/grumpy-masks-accept.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix Asset type

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -12,7 +12,18 @@ The manifest API is also the same between the server and client, development and
 You can access the manifest for any router by using calling `getManifest(routerName)` (exported by `vinxi/manifest`). This will give you a manifest object that looks like this:
 
 ```ts
-export type Asset = string;
+export type Asset = LinkAsset | ScriptOrStyleAsset;
+
+type LinkAsset = {
+	tag: 'link';
+	attrs: Record<string, string>
+}
+
+type ScriptOrStyleAsset = {
+	tag: 'script' | 'style';
+	attrs: Record<string, string>;
+	children?: string;
+}
 
 export type Manifest = {
   /** Name of the router */

--- a/packages/vinxi/types/manifest.d.ts
+++ b/packages/vinxi/types/manifest.d.ts
@@ -1,4 +1,15 @@
-export type Asset = string;
+export type Asset = LinkAsset | ScriptOrStyleAsset;
+
+type LinkAsset = {
+	tag: 'link';
+	attrs: Record<string, string>
+}
+
+type ScriptOrStyleAsset = {
+	tag: 'script' | 'style';
+	attrs: Record<string, string>;
+	children?: string;
+}
 
 export type Manifest = {
 	/** Name of the router */


### PR DESCRIPTION
I found that `Asset` type is wrong.

As I understood this is always object which has `tag` and `attrs`. When `tag` is `'script' | 'style'`, it also could be `children: string` in it.

So I updated type for this.