### PR TITLE
refactor: replace "dax-sh" with native "node:child_process"

### DIFF
--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -384,9 +384,9 @@ async function createViteBuild(config) {
 }
 
 async function createRouterBuildInWorker(app, router) {
-	const sh = await import("../runtime/sh.js");
+	const { $ } = await import("../runtime/sh.js");
 	const { fileURLToPath } = await import("url");
-	await sh.default`node ${fileURLToPath(
+	await $`node ${fileURLToPath(
 		new URL("../bin/cli.mjs", import.meta.url).href,
 	)} build --router=${router.name}`;
 }

--- a/packages/vinxi/package.json
+++ b/packages/vinxi/package.json
@@ -185,14 +185,11 @@
     "@babel/core": "^7.22.11",
     "@babel/plugin-syntax-jsx": "^7.22.5",
     "@babel/plugin-syntax-typescript": "^7.22.5",
-    "@types/micromatch": "^4.0.2",
     "@vinxi/listhen": "^1.5.6",
-    "boxen": "^7.1.1",
     "chokidar": "^3.5.3",
     "citty": "^0.1.4",
     "consola": "^3.2.3",
     "crossws": "^0.2.4",
-    "dax-sh": "^0.39.1",
     "defu": "^6.1.2",
     "es-module-lexer": "^1.3.0",
     "esbuild": "^0.20.2",
@@ -218,6 +215,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
+    "@types/micromatch": "^4.0.2",
     "@types/node": "^18.17.11",
     "@types/serve-static": "^1.15.2",
     "@types/resolve": "^1.20.6",

--- a/packages/vinxi/runtime/sh.js
+++ b/packages/vinxi/runtime/sh.js
@@ -1,2 +1,30 @@
-export * from "dax-sh"
-export { $ as default } from "dax-sh"
+import { spawn } from 'node:child_process';
+
+/**
+ * Executes a shell command asynchronously.
+ * @param {TemplateStringsArray} strings - The template string array.
+ * @param {...any} values - The interpolated values.
+ * @returns {Promise<null>} A promise that resolves when the command completes successfully, or rejects with an error.
+ * @throws {Error} If the command fails or encounters an error during execution.
+ */
+export function $(strings, ...values) {
+  const command = strings.reduce((result, str, i) => 
+    result + str + (values[i] || ''), '').trim();
+
+  return new Promise((resolve, reject) => {
+    const [cmd, ...args] = command.split(/\s+/);
+    const process = spawn(cmd, args, { shell: true, stdio: 'inherit' });
+
+    process.on('close', (code) => {
+      if (code === 0) {
+        resolve(null);
+      } else {
+        reject(new Error(`Command failed with exit code ${code}`));
+      }
+    });
+
+    process.on('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
Since node:child_process is supported on most popular javascript runtime like: bun, deno, workers ...