### PR TITLE
Fix docs syntax for proxy routeRules

### DIFF
--- a/docs/guide/route-rules.md
+++ b/docs/guide/route-rules.md
@@ -9,13 +9,17 @@ export default createApp({
   server: {
     routeRules: {
       "/_build/assets/**": { headers: { "cache-control": "s-maxage=0" } },
-      "/api/v1/**": {
-        cors: true,
-        headers: { "access-control-allow-methods": "GET" },
-      },
-      "/old-page": { redirect: { to: "/new-page" } },
-      "/proxy/example": { proxy: { to: "https://example.com" } },
-      "/proxy/**": { proxy: { to: "/api/**" } },
+      '/blog/**': { swr: true },
+      '/blog/**': { swr: 600 },
+      '/blog/**': { static: true },
+      '/blog/**': { cache: { /* cache options*/ } },
+      '/assets/**': { headers: { 'cache-control': 's-maxage=0' } },
+      '/api/v1/**': { cors: true, headers: { 'access-control-allow-methods': 'GET' } },
+      '/old-page': { redirect: '/new-page' }, // uses status code 307 (Temporary Redirect)
+      '/old-page2': { redirect: { to:'/new-page2', statusCode: 301 } },
+      '/old-page/**': { redirect: '/new-page/**' },
+      '/proxy/example': { proxy: 'https://example.com' },
+      '/proxy/**': { proxy: '/api/**' },
     },
   },
   routers: [

--- a/docs/guide/route-rules.md
+++ b/docs/guide/route-rules.md
@@ -13,9 +13,9 @@ export default createApp({
         cors: true,
         headers: { "access-control-allow-methods": "GET" },
       },
-      "/old-page": { redirect: "/new-page" },
-      "/proxy/example": { proxy: "https://example.com" },
-      "/proxy/**": { proxy: "/api/**" },
+      "/old-page": { redirect: { to: "/new-page" } },
+      "/proxy/example": { proxy: { to: "https://example.com" } },
+      "/proxy/**": { proxy: { to: "/api/**" } },
     },
   },
   routers: [


### PR DESCRIPTION
The configuration option requires a "to", which is omitted in the docs.