### PR TITLE
Add corepack, to help adjust pnpm version

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
+
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -25,5 +25,6 @@
   "dependencies": {
     "@changesets/cli": "^2.26.2",
     "rimraf": "^5.0.1"
-  }
+  },
+  "packageManager": "pnpm@8.15.9"
 }


### PR DESCRIPTION
This set in root package.json, the:

"packageManager": "pnpm@8.15.9"

Using `corepack enable` it'll automatically set the currently used pnpm version.

I made this PR, because I'm currently juggling a lot of `npm i -g pnpm@8 / 9` between solidjs repos, and this appear to work quite well for automating it.