### PR TITLE
Update collect-styles.js to use ?inline to get the css during ssr

### DIFF
--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -175,7 +175,11 @@ async function findStylesInModuleGraph(vite, match, ssr) {
 
 		if (isCssFile(dep.url ?? "")) {
 			try {
-				const mod = await vite.ssrLoadModule(dep.url);
+				let [path, query] = dep.url.split('?')
+				let searchParams = new URLSearchParams(query)
+				searchParams.set("inline", true)
+				let inlineDepURL = path + '?' + searchParams.toString()
+				const mod = await vite.ssrLoadModule(inlineDepURL);
 				if (isCssModulesFile(dep.file)) {
 					styles[join(vite.config.root, dep.url)] = vite.cssModules?.[dep.file];
 				} else {


### PR DESCRIPTION
Because of this fix, https://github.com/vitejs/vite/pull/17922, our way of importing css as js modules with default exports with css text, stopped working.

We are expected to use ?inline query to get the desired format, so this fixes that