### PR TITLE
feat(vinxi-react-server-dom): open vite peerDeps to version 6

### DIFF
--- a/.changeset/nervous-llamas-doubt.md
+++ b/.changeset/nervous-llamas-doubt.md
@@ -1,0 +1,5 @@
+---
+@vinxi/react-server-dom: patch
+---
+
+feat(vinxi-react-server-dom): open vite peerDeps to version 6

--- a/vendor/react-server-dom-vite/package.json
+++ b/vendor/react-server-dom-vite/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "react": "0.0.0-experimental-035a41c4e-20230704",
     "react-dom": "0.0.0-experimental-035a41c4e-20230704",
-    "vite": "^4.3.9"
+    "vite": "^4.3.9 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "acorn-loose": "^8.3.0"


### PR DESCRIPTION
Originating from https://github.com/TanStack/router/issues/2931, where the vite's `peerDeps` for the `@vinxi/react-server-dom` package was at `^4.3.9`.

This change opens vite's `peerDeps` range from `^4.3.9` to `^4.3.9 || ^5.0.0 || ^6.0.0`.

From https://github.com/nksaraf/vinxi/pull/431