### PR TITLE
fixed crossws 0.3.0 compatibility

### DIFF
--- a/packages/vinxi/lib/nitro-dev.js
+++ b/packages/vinxi/lib/nitro-dev.js
@@ -293,26 +293,7 @@ export async function createDevServer(nitro) {
 	// 	}),
 	// );
 
-	const adapter = wsAdapter({
-		...wsApp.websocket,
-		hooks: {
-			open: (event) => {
-				event.ctx.node.req.url = event.ctx.node.req.originalUrl;
-			},
-			message: (event) => {
-				event.ctx.node.req.url = event.ctx.node.req.originalUrl;
-			},
-			close: (event) => {
-				event.ctx.node.req.url = event.ctx.node.req.originalUrl;
-			},
-			error: (event) => {
-				event.ctx.node.req.url = event.ctx.node.req.originalUrl;
-			},
-			upgrade: (event) => {
-				// event.ctx.node.req.url = event.ctx.node.req.originalUrl;
-			},
-		},
-	});
+	const adapter = wsAdapter(wsApp.websocket);
 	// Listen
 	/** @type {import("@vinxi/listhen").Listener[]}  */
 	let listeners = [];


### PR DESCRIPTION
crossws 0.3.0 renamed ctx to _internal:

https://github.com/unjs/crossws/releases/tag/v0.3.0

This broke vinxi when using this version of crossws and crashes the app.

I didn't see the use of this in nitro-dev, so I removed it. If this still has use, let me know what it is and I'll figure it out.

Thank you!