### PR TITLE
Enable vite `mode` flag

### DIFF
--- a/.changeset/shy-jokes-learn.md
+++ b/.changeset/shy-jokes-learn.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+enable vite mode flag via cli

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -232,7 +232,7 @@ const command = defineCommand({
 				}
 				process.env.NODE_ENV = "production";
 				const { createBuild } = await import("../lib/build.js");
-				await createBuild(app, { preset: args.preset, router: args.router });
+				await createBuild(app, { preset: args.preset, router: args.router, mode: args.mode });
 			},
 		},
 		start: {

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -400,7 +400,7 @@ async function createViteBuild(config) {
  *
  * @param {import("./app.js").App} app
  * @param {import("./router-mode.js").Router} router
- * @param {string?} mode
+ * @param {string} [mode]
  */
 async function createRouterBuildInWorker(app, router, mode) {
 	const sh = await import("../runtime/sh.js");
@@ -413,7 +413,7 @@ async function createRouterBuildInWorker(app, router, mode) {
  *
  * @param {import("./app.js").App} app
  * @param {import("./router-mode.js").Router} router
- * @param {string?} mode
+ * @param {string} [mode]
  */
 async function createRouterBuild(app, router, mode) {
 	console.log("\n");


### PR DESCRIPTION
The mode argument was not being passed to `vite.build()` in `createViteBuild()`

This fixes #378 