### PR TITLE
fix: delete url parameter for ssrLoadModule calls in findStylesInModuleGraph

### DIFF
--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -177,6 +177,7 @@ async function findStylesInModuleGraph(vite, match, ssr) {
 			try {
 				let [path, query] = dep.url.split('?')
 				let searchParams = new URLSearchParams(query)
+				searchParams.delete("url")
 				searchParams.set("inline", true)
 				let inlineDepURL = path + '?' + searchParams.toString()
 				const mod = await vite.ssrLoadModule(inlineDepURL);


### PR DESCRIPTION
Importing a css file with `?url` results in
`Error when evaluating SSR module` errors during `vite dev`. The error is caused by Vinxi appending `&inline=true` for the ssrLoadModule calls. Vite `ssrLoadModule` expects urls to only have `?inline`, the user-provided `url` parameter has to be removed.

Detailed error:
```
Error when evaluating SSR module /src/styles.css?url=&inline=true:
|- RollupError: Parse failure: Expression expected
At file: /src/styles.css?url=&inline=true:1:1
```

## Reproduction:
[vinxi-vite6-css-urls.zip](https://github.com/user-attachments/files/18672267/vinxi-vite6-css-urls.zip)

1. pnpm install && pnpm dev
2. Open `localhost:3000` in the browser
3. The error will be logged in the shell

Branches:
- vite6: vite 6, vinxi 5 - Error occurs
- master: vite 5, vinxi 4 - No error

## Refs
solidjs/solid-start#1756