### PR TITLE
fix: exclude css with sideeffects from ssr during dev

### DIFF
--- a/.changeset/six-schools-ring.md
+++ b/.changeset/six-schools-ring.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+Fix a regression that caused css imported with sideeffects such as `?url`, to be rendered during ssr (in dev).

--- a/packages/vinxi/lib/manifest/collect-styles.js
+++ b/packages/vinxi/lib/manifest/collect-styles.js
@@ -159,6 +159,40 @@ const isCssFile = (/** @type {string} */ file) => cssFileRegExp.test(file);
 export const isCssModulesFile = (/** @type {string} */ file) =>
 	cssModulesRegExp.test(file);
 
+// https://github.com/remix-run/remix/blob/65326e39099f3b2285d83aecfe734ba35f668396/packages/remix-dev/vite/styles.ts#L29
+const cssUrlParamsWithoutSideEffects = ["url", "inline", "raw", "inline-css"];
+export const isCssUrlWithoutSideEffects = (/** @type {string} */ url) => {
+	const queryString = url.split("?")[1];
+
+	if (!queryString) {
+		return false;
+	}
+
+	const params = new URLSearchParams(queryString);
+	for (let paramWithoutSideEffects of cssUrlParamsWithoutSideEffects) {
+		if (
+			// Parameter is blank and not explicitly set, i.e. "?url", not "?url="
+			params.get(paramWithoutSideEffects) === "" &&
+			!url.includes(`?${paramWithoutSideEffects}=`) &&
+			!url.includes(`&${paramWithoutSideEffects}=`)
+		) {
+			return true;
+		}
+	}
+
+	return false;
+};
+
+/**
+ * 
+ * @param {string} url 
+ * @param {string} query 
+ * Source: https://github.com/remix-run/remix/pull/10254
+ * @returns 
+ */
+const injectQuery = (url, query) =>
+	url.includes("?") ? url.replace("?", `?${query}&`) : `${url}?${query}`;
+
 /**
  *
  * @param {import('vite').ViteDevServer} vite
@@ -170,17 +204,14 @@ async function findStylesInModuleGraph(vite, match, ssr) {
 	const dependencies = await findDependencies(vite, match, ssr);
 
 	for (const dep of dependencies) {
-		const parsed = new URL(dep.url, "http://localhost/");
-		const query = parsed.searchParams;
-
 		if (isCssFile(dep.url ?? "")) {
 			try {
-				let [path, query] = dep.url.split('?')
-				let searchParams = new URLSearchParams(query)
-				searchParams.delete("url")
-				searchParams.set("inline", true)
-				let inlineDepURL = path + '?' + searchParams.toString()
-				const mod = await vite.ssrLoadModule(inlineDepURL);
+				let depURL = dep.url;
+				if (!isCssUrlWithoutSideEffects(depURL)) {
+					depURL = injectQuery(dep.url, "inline");
+				}
+
+				const mod = await vite.ssrLoadModule(depURL);
 				if (isCssModulesFile(dep.file)) {
 					styles[join(vite.config.root, dep.url)] = vite.cssModules?.[dep.file];
 				} else {


### PR DESCRIPTION
## IS
All CSS imported with `?url` and other such sideeffects is rendered on the server during DEV. This is a regression introduced with b6d9643 / 1ac2df3.

## SHOULD
CSS imported with sideeffects should not be rendered on the server during DEV. The goal here is to bring vinxi > v0.5 CSS rendering back in line with v0.4.3. This wont fix inconsistencies already existing from the v0.4.3 days (thus the red entries under "SHOULD" in the comparison table 😅).

The new `cssUrlParamsWithoutSideEffects` and
`injectQuery` functions are copied from Remix, opening up further future alignment of the logic.

## How was this tested?
- Applied patch in a local copy of the `Vinxi 0.5.2 & Vite 6` stackblitz. The results of this are included in the comparison table in the `After fix` columns.
- Applied patch in a real project [nitropage](https://github.com/nitropage/nitropage) (with Vinxi 0.5.2 & Vite 6).

### Stackblitz Playgrounds
The stackblitzes below include several different types of CSS include methods and show how they act depending on `dev vs prod` `ssr-only vs hydration`.

Vinxi 0.5.2 & Vite 6: https://stackblitz.com/edit/github-gpsedpxc-1muqhav6?file=src%2Froutes%2Findex.tsx
Vinxi 0.4.3 & Vite 5: https://stackblitz.com/edit/github-gpsedpxc?file=src%2Froutes%2Findex.tsx

### Comparison table
<img width="5600" alt="Combined" src="https://github.com/user-attachments/assets/ee832f4d-4f3f-46d9-8772-97aeb0e3a8d0" />

## References:
Root cause (including refs to solutions of other frameworks): vitejs/vite#17922