### PR TITLE
feat: allow custom `clearScreen` configuration

### DIFF
--- a/.changeset/proud-queens-develop.md
+++ b/.changeset/proud-queens-develop.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+feat: allow custom `clearScreen` configuration

--- a/packages/vinxi/lib/vite-dev.d.ts
+++ b/packages/vinxi/lib/vite-dev.d.ts
@@ -39,7 +39,6 @@ export type CustomizableConfig = Omit<
 	| "mode"
 	| "server"
 	| "preview"
-	| "clearScreen"
 	| "configFile"
 	| "envFile"
 > & {


### PR DESCRIPTION
Removed it from `Omit` as I didn't find any reason to keep it there


fixes #466 