### PR TITLE
fix: ensure --mode flag works for `dev` commad

### DIFF
--- a/.changeset/afraid-tigers-chew.md
+++ b/.changeset/afraid-tigers-chew.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix mode arg for dev command

--- a/packages/vinxi/bin/cli.mjs
+++ b/packages/vinxi/bin/cli.mjs
@@ -74,6 +74,7 @@ const command = defineCommand({
 				const configFile = args.config;
 				globalThis.MANIFEST = {};
 				const app = await loadApp(configFile, args);
+				app.config.mode = args.mode;
 
 				log(c.dim(c.green("starting dev server")));
 				let devServer;


### PR DESCRIPTION
This ensures the `--mode` CLI arg is ultimately passed to the `vite` dev server. I wasn't quite sure where best do this, and I don't love mutating a property on an object, but this seems to work well.

Fixes https://github.com/nksaraf/vinxi/issues/471