### PR TITLE
fix: nitro H3Event extension

### DIFF
--- a/.changeset/gorgeous-bees-talk.md
+++ b/.changeset/gorgeous-bees-talk.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: nitro H3Event extension

--- a/packages/vinxi/package.json
+++ b/packages/vinxi/package.json
@@ -198,7 +198,7 @@
     "esbuild": "^0.25.3",
     "fast-glob": "^3.3.3",
     "get-port-please": "^3.1.2",
-    "h3": "1.15.2",
+    "h3": "1.15.3",
     "hookable": "^5.5.3",
     "http-proxy": "^1.18.1",
     "micromatch": "^4.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -834,8 +834,8 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
       h3:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.15.3
+        version: 1.15.3
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
@@ -7654,7 +7654,7 @@ packages:
       consola: 3.4.2
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.15.2
+      h3: 1.15.3
       http-shutdown: 1.2.2
       jiti: 1.21.0
       mlly: 1.5.0
@@ -11028,8 +11028,8 @@ packages:
       unenv: 1.10.0
     dev: false
 
-  /h3@1.15.2:
-    resolution: {integrity: sha512-28QobU1/digpHI/kA9ttYnYtIS3QOtuvx3EY4IpFR+8Bh2C2ugY/ovSg/1LeqATXlznvZnwewWyP2S9lZPiMVA==}
+  /h3@1.15.3:
+    resolution: {integrity: sha512-z6GknHqyX0h9aQaTx22VZDf6QyZn+0Nh+Ym8O/u0SGSkyF5cuTJYKlc8MkzW3Nzf9LE1ivcpmYC3FUGpywhuUQ==}
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.4
@@ -11964,7 +11964,7 @@ packages:
       crossws: 0.2.4
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.15.2
+      h3: 1.15.3
       http-shutdown: 1.2.2
       jiti: 1.21.0
       mlly: 1.6.1
@@ -11990,7 +11990,7 @@ packages:
       crossws: 0.3.4
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.15.2
+      h3: 1.15.3
       http-shutdown: 1.2.2
       jiti: 2.4.2
       mlly: 1.7.4
@@ -13285,7 +13285,7 @@ packages:
       exsolve: 1.0.5
       globby: 14.1.0
       gzip-size: 7.0.0
-      h3: 1.15.2
+      h3: 1.15.3
       hookable: 5.5.3
       httpxy: 0.1.7
       ioredis: 5.6.1
@@ -13396,7 +13396,7 @@ packages:
       fs-extra: 11.3.0
       globby: 14.1.0
       gzip-size: 7.0.0
-      h3: 1.15.2
+      h3: 1.15.3
       hookable: 5.5.3
       httpxy: 0.1.7
       ioredis: 5.5.0
@@ -16431,7 +16431,7 @@ packages:
       anymatch: 3.1.3
       chokidar: 4.0.3
       destr: 2.0.3
-      h3: 1.15.2
+      h3: 1.15.3
       lru-cache: 10.4.3
       node-fetch-native: 1.6.6
       ofetch: 1.4.1
@@ -16501,7 +16501,7 @@ packages:
       chokidar: 4.0.3
       db0: 0.3.1
       destr: 2.0.5
-      h3: 1.15.2
+      h3: 1.15.3
       ioredis: 5.5.0
       lru-cache: 10.4.3
       node-fetch-native: 1.6.6
@@ -16572,7 +16572,7 @@ packages:
       chokidar: 4.0.3
       db0: 0.3.2
       destr: 2.0.5
-      h3: 1.15.2
+      h3: 1.15.3
       ioredis: 5.6.1
       lru-cache: 10.4.3
       node-fetch-native: 1.6.6


### PR DESCRIPTION
now we'll get things like `waitUntil` in `getRequestEvent()?.nativeEvent` in solid and other frameworks