### PR TITLE
fix: server code leaked in client bundle in compressed js files.

### DIFF
--- a/.changeset/mean-plants-mix.md
+++ b/.changeset/mean-plants-mix.md
@@ -1,0 +1,5 @@
+---
+"vinxi": patch
+---
+
+fix: server code leaked in client bundle in compressed js files.

--- a/packages/vinxi/lib/build.js
+++ b/packages/vinxi/lib/build.js
@@ -348,7 +348,10 @@ export async function createBuild(app, buildConfig, configFile) {
 			if (
 				assetName.endsWith(".js") ||
 				assetName.endsWith(".mjs") ||
-				assetName.endsWith(".cjs")
+				assetName.endsWith(".cjs") ||
+				assetName.includes(".js.") ||
+				assetName.includes(".cjs.") ||
+				assetName.includes(".mjs.")
 			) {
 				if (!hasFilesDeleted) {
 					hasFilesDeleted = true;


### PR DESCRIPTION
added condition for removing files to match

server files leak into client in compressed js|cjs|mjs files 

enhanced the condition to remove files from public directory in build to include compressed js files